### PR TITLE
[GH #126] Select Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rolemodel/optics",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "modern-css-reset": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/scss/optics.scss",
   "scripts": {

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -1,6 +1,10 @@
 %standard-input {
+  // Private API (don't touch these)
+  --__rm-input-min-height: calc(3 * var(--rm-space-medium));
+
   display: block;
   width: 100%;
+  min-width: var(--__rm-input-min-height);
   height: var(--rm-input-height-large);
   padding: var(--rm-space-small) var(--rm-space-medium);
   border: none;
@@ -60,10 +64,6 @@
 
   &[type='color'] {
     @extend %dropdown-arrow;
-
-    &::-webkit-color-swatch {
-      margin-right: var(--rm-space-2x-large);
-    }
   }
 
   &[type='radio'],

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -29,9 +29,10 @@
 }
 
 %dropdown-arrow {
+  padding-right: var(--rm-space-x-large);
   appearance: none;
   background: var(--rm-form-dropdown-arrow) center right no-repeat;
-  background-position-x: calc(100% - var(--rm-space-small));
+  background-position-x: calc(100% - ((var(--rm-space-x-large) / 2) - (var(--rm-form-dropdown-arrow-width) / 2)));
   cursor: pointer;
 }
 
@@ -98,8 +99,7 @@
   }
 }
 
-select.form-control {
-  @extend %standard-input;
+select.form-control:not([type='radio'], [type='checkbox']) {
   @extend %dropdown-arrow;
 }
 

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -99,8 +99,12 @@
   }
 }
 
-select.form-control:not([type='radio'], [type='checkbox']) {
+select.form-control:not([multiple], [type='radio'], [type='checkbox']) {
   @extend %dropdown-arrow;
+}
+
+select.form-control[multiple] {
+  min-height: calc(2 * var(--__rm-input-height));
 }
 
 textarea.form-control {

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -33,10 +33,10 @@
 }
 
 %dropdown-arrow {
-  padding-right: var(--rm-space-x-large);
+  padding-right: var(--rm-space-3x-large);
   appearance: none;
   background: var(--rm-form-dropdown-arrow) center right no-repeat;
-  background-position-x: calc(100% - ((var(--rm-space-x-large) / 2) - (var(--rm-form-dropdown-arrow-width) / 2)));
+  background-position-x: calc(100% - ((var(--rm-space-3x-large) / 2) - (var(--rm-form-dropdown-arrow-width) / 2)));
   cursor: pointer;
 }
 

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -1,11 +1,11 @@
 %standard-input {
   // Private API (don't touch these)
-  --__rm-input-min-height: calc(3 * var(--rm-space-medium));
+  --__rm-input-height: var(--rm-input-height-large);
 
   display: block;
   width: 100%;
-  min-width: var(--__rm-input-min-height);
-  height: var(--rm-input-height-large);
+  min-width: var(--__rm-input-height);
+  height: var(--__rm-input-height);
   padding: var(--rm-space-small) var(--rm-space-medium);
   border: none;
   border-radius: var(--rm-radius-large);
@@ -27,7 +27,7 @@
     cursor: unset;
 
     &[type='color'] {
-      height: var(--rm-input-height-large);
+      height: var(--__rm-input-height);
     }
   }
 }
@@ -106,9 +106,9 @@ select.form-control:not([type='radio'], [type='checkbox']) {
 textarea.form-control {
   @extend %standard-input;
 
-  min-width: var(--rm-input-height-large);
+  min-width: var(--__rm-input-height);
   max-width: 100%;
-  min-height: var(--rm-input-height-large);
+  min-height: var(--__rm-input-height);
 }
 
 .form-group--error {

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -123,7 +123,8 @@
 }
 
 @mixin encoded-images {
-  --rm-form-dropdown-arrow: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDI5IDE0IiB3aWR0aD0iMjkiPjxwYXRoIGZpbGw9IiNkMWQxZDEiIGQ9Ik05LjM3NzI3IDMuNjI1bDUuMDgxNTQgNi45MzUyM0wxOS41NDAzNiAzLjYyNSIvPjwvc3ZnPgo=');
+  --rm-form-dropdown-arrow-width: 1rem; // No way to string interpolate
+  --rm-form-dropdown-arrow: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 7' version='1.1' xmlns='http://www.w3.org/2000/svg' width='10' height='7'%3E%3Cg transform='matrix(0.983953,0,0,1.00934,-9.22679,-3.65885)'%3E%3Cpath fill='%23d1d1d1' d='M9.37727 3.625l5.08154 6.93523L19.54036 3.625'/%3E%3C/g%3E%3C/svg%3E%0A");
 }
 
 @mixin fonts {

--- a/src/stories/1_Introduction.stories.mdx
+++ b/src/stories/1_Introduction.stories.mdx
@@ -7,7 +7,7 @@ import { version } from '../../package.json'
 
 <h2>V{version}</h2>
 
-Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.
+[Optics](https://github.com/RoleModel/optics) is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.
 
 ## Installation
 

--- a/src/stories/Form/Form.js
+++ b/src/stories/Form/Form.js
@@ -89,10 +89,14 @@ export const createTextarea = ({ readonly }) => {
   return input
 }
 
-export const createSelect = ({ options, readonly }) => {
+export const createSelect = ({ options, readonly, multiple }) => {
   const element = readonly ? 'div' : 'select'
   const input = document.createElement(element)
   input.className = 'form-control'
+
+  if (multiple) {
+    input.setAttribute('multiple', true)
+  }
 
   if (readonly) {
     input.className += ' form-control--read-only'

--- a/src/stories/Select.stories.js
+++ b/src/stories/Select.stories.js
@@ -14,6 +14,9 @@ export default {
     readonly: {
       control: { type: 'boolean' },
     },
+    multiple: {
+      control: { type: 'boolean' },
+    },
   },
   parameters: {
     docs: {
@@ -29,4 +32,5 @@ const Template = ({ options, ...args }) => {
 export const Default = Template.bind({})
 Default.args = {
   options: 1,
+  multiple: false,
 }


### PR DESCRIPTION
## Task

#126 

## Why?

Select dropdowns inside of a flexible container result in the arrow overlapping the text.

## What Changed

- [X] Fix the dropdown arrow
- [X] Start following semantic versioning and drop beta
- [X] Update docs to have link to repo

Note: It still does clip the contents within the select if it's small enough but the arrow doesn't overlap strangely. I think this is an inherent limitation of styling select elements. Setting a min-width override if you absolutely need it is an option, but would be context driven.

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- [X] Do you need to update the package version?

## Screenshots

<img width="245" alt="Screenshot 2023-01-26 at 10 36 19 PM" src="https://user-images.githubusercontent.com/5957102/215007230-4e8e6953-a587-4a04-bd7e-7ec3136c6f37.png">
<img width="790" alt="Screenshot 2023-01-26 at 10 36 27 PM" src="https://user-images.githubusercontent.com/5957102/215007231-48fe4892-5cf0-4083-8cfd-5d7772bf59a3.png">
<img width="293" alt="Screenshot 2023-01-26 at 10 57 29 PM" src="https://user-images.githubusercontent.com/5957102/215007232-41d6a412-7198-4237-81e4-cfce1e648e3e.png">

<img width="436" alt="Screenshot 2023-01-26 at 11 10 11 PM" src="https://user-images.githubusercontent.com/5957102/215007695-8022fe18-34c4-444d-8288-5697d6122d03.png">

![Screenshot 2023-01-27 at 11 10 58 AM](https://user-images.githubusercontent.com/5957102/215136718-8563295a-69d8-43ec-8f48-33355c0ebc44.png)
