### PR TITLE
[GHI #98] Deployment strategy

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,21 +1,29 @@
-name: Node.js Package
+name: Deploy to NPM and GHP
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
-  build:
+  build-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  build-gph:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: https://npm.pkg.github.com/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Optics, a RoleModel Design System
 
+[![Linting CI](https://github.com/RoleModel/optics/actions/workflows/linting.yml/badge.svg)](https://github.com/RoleModel/optics/actions/workflows/linting.yml)
+
 Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rolemodel/optics",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "modern-css-reset": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/scss/optics.scss",
   "scripts": {


### PR DESCRIPTION
## Task

#98 

## Why?

We want to publish to both NPM and GHP to allow Optics to be used in conjunction with Private Repositories in GHP.

## What Changed?

- [X] Add Linting Status to README
- [X] Renamed Publish Workflow
- [X] Update Publish workflow to deploy to Github Packages and NPM
- [X] Change Workflow trigger to publish on release published (this should catch draft Releases as well)

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you run linters?~~
- ~~Have you run prettier?~~
- ~~Have you tried building the css?~~
- ~~Have you tried building storybook?~~
- [X] Do you need to update the package version?
