### PR TITLE
Form Group Refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rolemodel/optics",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "modern-css-reset": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/scss/optics.scss",
   "scripts": {

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -15,7 +15,6 @@
   cursor: text;
   font-size: var(--rm-font-small);
   font-weight: var(--rm-font-weight-light);
-  grid-column: 1 / 3; // Group Alignment
   line-height: var(--rm-line-height-base);
 
   &.form-control--read-only {
@@ -40,19 +39,10 @@
   cursor: pointer;
 }
 
-.form-group {
-  display: grid;
-  padding: var(--rm-space-small) 0;
-  gap: var(--rm-space-x-small);
-  grid-auto-rows: auto;
-  grid-template-columns: auto 1fr;
-}
-
 .form-label {
   color: var(--rm-color-on-background);
   font-size: var(--rm-font-small);
   font-weight: var(--rm-font-weight-normal);
-  grid-column: 1 / 3; // Group Alignment
   letter-spacing: var(--rm-letter-spacing-label);
   line-height: var(--rm-line-height-base);
 }
@@ -74,7 +64,6 @@
     margin: 0;
     accent-color: var(--rm-color-primary-base);
     cursor: pointer;
-    grid-column: 1 / 1; // Group Alignment
 
     & + .form__label {
       grid-column: 2 / 3;
@@ -140,14 +129,12 @@ textarea.form-control {
   background: var(--rm-color-alerts-danger-plus-seven);
   color: var(--rm-color-alerts-danger-on-plus-seven);
   font-size: var(--rm-font-x-small);
-  grid-column: 1 / 3; // Group Alignment
 }
 
 .form-hint {
   display: block;
   font-size: var(--rm-font-small);
   font-style: italic;
-  grid-column: 1 / 3; // Group Alignment
 }
 
 .form-error-summary {
@@ -164,5 +151,28 @@ textarea.form-control {
 
   ul {
     margin-bottom: 0;
+  }
+}
+
+.form-group {
+  display: grid;
+  padding: var(--rm-space-small) 0;
+  gap: var(--rm-space-x-small);
+  grid-auto-rows: auto;
+  grid-template-columns: auto 1fr;
+
+  // Group Alignment
+  /* stylelint-disable no-descending-specificity */
+  .form-label,
+  .form-error,
+  .form-hint,
+  .form-control:not([type='radio'], [type='checkbox']) {
+    grid-column: 1 / 3;
+  }
+  /* stylelint-enable no-descending-specificity */
+
+  .form-control[type='radio'],
+  .form-contorl[type='checkbox'] {
+    grid-column: 1 / 1;
   }
 }


### PR DESCRIPTION
## Why?

`.form-control` has a grid style on it for positioning in a group (for alignment with label, hint, errors).
In cases where you want a styled input but not in a group (I.E. a calendar month or year dropdown), the input inherits grid styling from a parent and tries to align to in incorrectly.

## What Changed

- [X] Refactor form styles to only apply grid positioning when used within a form-group

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- [X] Do you need to update the package version?