### PR TITLE
prevent form-error from shifting form-group [fix #138]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rolemodel/optics",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "modern-css-reset": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/scss/optics.scss",
   "scripts": {

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -160,6 +160,7 @@ textarea.form-control {
   gap: var(--rm-space-x-small);
   grid-auto-rows: auto;
   grid-template-columns: auto 1fr;
+  grid-template-rows: repeat(3, min-content);
 
   // Group Alignment
   /* stylelint-disable no-descending-specificity */
@@ -172,18 +173,8 @@ textarea.form-control {
   /* stylelint-enable no-descending-specificity */
 
   .form-control[type='radio'],
-  .form-contorl[type='checkbox'] {
+  .form-control[type='checkbox'] {
     grid-column: 1 / 1;
-  }
 
-  /* create a new positioning context for absolutly positioned children */
-  transform: translateY(0);
-
-  .form-error {
-    position: absolute;
-
-    /* the bottom of it's positioning context + 50% of it's own height */
-    bottom: 0;
-    transform: translateY(50%);
   }
 }

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -64,11 +64,6 @@
     margin: 0;
     accent-color: var(--rm-color-primary-base);
     cursor: pointer;
-
-    & + .form__label {
-      grid-column: 2 / 3;
-      grid-row: 1;
-    }
   }
 
   &:disabled {
@@ -176,5 +171,9 @@ textarea.form-control {
   .form-control[type='checkbox'] {
     grid-column: 1 / 1;
 
+    & + .form-label {
+      grid-column: 2 / 3;
+      grid-row: 1;
+    }
   }
 }

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -151,11 +151,11 @@ textarea.form-control {
 
 .form-group {
   display: grid;
+  align-content: baseline;
   padding: var(--rm-space-small) 0;
   gap: var(--rm-space-x-small);
   grid-auto-rows: auto;
   grid-template-columns: auto 1fr;
-  grid-template-rows: repeat(3, min-content);
 
   // Group Alignment
   /* stylelint-disable no-descending-specificity */

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -178,8 +178,10 @@ textarea.form-control {
 
   /* create a new positioning context for absolutly positioned children */
   transform: translateY(0);
+
   .form-error {
     position: absolute;
+
     /* the bottom of it's positioning context + 50% of it's own height */
     bottom: 0;
     transform: translateY(50%);

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -175,4 +175,13 @@ textarea.form-control {
   .form-contorl[type='checkbox'] {
     grid-column: 1 / 1;
   }
+
+  /* create a new positioning context for absolutly positioned children */
+  transform: translateY(0);
+  .form-error {
+    position: absolute;
+    /* the bottom of it's positioning context + 50% of it's own height */
+    bottom: 0;
+    transform: translateY(50%);
+  }
 }


### PR DESCRIPTION
## Task

see issue #138 

## Screenshots

![2023-02-16 14 05 12](https://user-images.githubusercontent.com/1504753/219479003-0795d808-68ff-4a4a-b4ce-161ff84d97c4.gif)

CSS [SubGrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid) would provide a much more elegant solution..

I can imagine a `.form-row` taking over for `.form-group` with it's own grid area.  So, given `.form-row > .form-group*n > .form-label+.form-control+.form-error` each label/control/error would occupy a grid-row with their respective siblings in neighboring `.form-groups`.  Alas

![Screenshot 2023-02-16 at 3 35 13 PM](https://user-images.githubusercontent.com/1504753/219492210-a6b33cc8-3d6f-4224-8e43-d8bf9c5e1c67.png)

