### PR TITLE
[GHI #142] Release Template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,13 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -32,6 +32,9 @@ changelog:
     - title: Repository Changes
       labels:
         - Repository Change
+    - title: Documentation Changes
+      labels:
+        - documentation
     - title: Unlabeled Changes (please categorize these)
       labels:
         - '*'
@@ -47,3 +50,4 @@ changelog:
           - Breaking Change
           - dependencies
           - Repository Change
+          - documentation

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,9 @@
 
 changelog:
   categories:
+    - title: Breaking Changes
+      labels:
+        - Breaking Change
     - title: Base Token Changes
       labels:
         - Base Tokens
@@ -23,9 +26,6 @@ changelog:
     - title: Addon Changes
       labels:
         - Addons
-    - title: Breaking Changes
-      labels:
-        - Breaking Change
     - title: Dependencies
       labels:
         - dependencies
@@ -40,6 +40,7 @@ changelog:
         - '*'
       exclude:
         labels:
+          - Breaking Change
           - Base Tokens
           - Theme Tokens
           - Base Reset
@@ -47,7 +48,6 @@ changelog:
           - Components
           - Utilities
           - Addons
-          - Breaking Change
           - dependencies
           - Repository Change
           - documentation

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,12 +2,48 @@
 
 changelog:
   categories:
-    - title: 🏕 Features
+    - title: Base Token Changes
+      labels:
+        - Base Tokens
+    - title: Theme Token Changes
+      labels:
+        - Theme Tokens
+    - title: Base Reset Changes
+      labels:
+        - Base Reset
+    - title: Layout Changes
+      labels:
+        - Layout
+    - title: Component Changes
+      labels:
+        - Components
+    - title: Utility Changes
+      labels:
+        - Utilities
+    - title: Addon Changes
+      labels:
+        - Addons
+    - title: Breaking Changes
+      labels:
+        - Breaking Change
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Repository Changes
+      labels:
+        - Repository Change
+    - title: Unlabeled Changes (please categorize these)
       labels:
         - '*'
       exclude:
         labels:
+          - Base Tokens
+          - Theme Tokens
+          - Base Reset
+          - Layout
+          - Components
+          - Utilities
+          - Addons
+          - Breaking Change
           - dependencies
-    - title: 👒 Dependencies
-      labels:
-        - dependencies
+          - Repository Change


### PR DESCRIPTION
## Task

#142 

## Why?

We want to add a clear labeling scheme for our releases. This allows us to auto generate release notes pre categorized.

## What Changed

- [X] Add configuration for release note auto generation

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you run linters?~~
- ~~Have you run prettier?~~
- ~~Have you tried building the css?~~
- ~~Have you tried building storybook?~~
- ~~Do you need to update the package version?~~

## Screenshots

Here is an example if we included every versions changes.
Note: Breaking Changes was moved to the top.

![Screenshot 2023-02-28 at 6 59 27 PM](https://user-images.githubusercontent.com/5957102/222011365-362162ac-8968-4943-b462-58dd87ee955f.png)
![Screenshot 2023-02-28 at 6 59 34 PM](https://user-images.githubusercontent.com/5957102/222011367-3983ddeb-9e8b-4de9-8dce-dffbf5c09d54.png)
![Screenshot 2023-02-28 at 6 59 44 PM](https://user-images.githubusercontent.com/5957102/222011369-81579810-6e3b-493b-acf9-f45203343664.png)
