### PR TITLE
[GHI #101] Font and Line Height

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -1,6 +1,7 @@
 name: Build and Deploy Storybook Documentation
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 

--- a/.storybook/documentation.scss
+++ b/.storybook/documentation.scss
@@ -1,6 +1,9 @@
 @import './src/optics.scss';
 
-@keyframes transitionDemo {
+@import './src/recipes/domains-sidebar.scss';
+@import './src/recipes/16six-sidebar.scss';
+
+@keyframes transition-demo {
   from {
     background-color: var(--rm-color-white);
     color: var(--rm-color-black);
@@ -14,45 +17,44 @@
 
 .transition-demo {
   display: inline-block;
-
-  background-color: var(--rm-color-primary-base);
-  color: var(--rm-color-primary-on-base);
-
   padding: var(--rm-space-medium);
-
-  animation-name: transitionDemo;
   animation-duration: var(--rm-transition-input);
   animation-iteration-count: 1;
+  animation-name: transition-demo;
+  background-color: var(--rm-color-primary-base);
+  color: var(--rm-color-primary-on-base);
 }
 
 .transition-demo--input {
   animation-duration: var(--rm-transition-input);
 }
+
 .transition-demo--navigation {
   animation-duration: var(--rm-transition-navigation);
 }
+
 .transition-demo--sidebar {
   animation-duration: var(--rm-transition-sidebar);
 }
+
 .transition-demo--modal {
   animation-duration: var(--rm-transition-modal);
 }
+
 .transition-demo--panel {
   animation-duration: var(--rm-transition-panel);
 }
+
 .transition-demo--flash {
   animation-duration: var(--rm-transition-flash);
 }
 
 .flash--demo {
   position: relative;
-  animation: none;
   top: 0;
   right: 0;
+  animation: none;
 }
-
-@import './src/recipes/domains-sidebar.scss';
-@import './src/recipes/16six-sidebar.scss';
 
 .background-primary-plus-four {
   background-color: var(--rm-color-primary-plus-four);

--- a/.storybook/documentation.scss
+++ b/.storybook/documentation.scss
@@ -3,6 +3,8 @@
 @import './src/recipes/domains-sidebar.scss';
 @import './src/recipes/16six-sidebar.scss';
 
+@import 'https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap';
+
 @keyframes transition-demo {
   from {
     background-color: var(--rm-color-white);
@@ -64,4 +66,9 @@
 .background-primary-plus-seven {
   background-color: var(--rm-color-primary-plus-seven);
   color: var(--rm-color-primary-on-plus-seven);
+}
+
+.font-family-demo--alternative {
+  --rm-font-family: 'Tilt Neon', sans-serif;
+  font-family: var(--rm-font-family);
 }

--- a/src/stories/4_ScaleOverriding.stories.mdx
+++ b/src/stories/4_ScaleOverriding.stories.mdx
@@ -12,10 +12,17 @@ A Unit Scale is defined for both font sizes and spacing variables. All values ar
 
 If you want to change the font or spacing scale globally, or within the context of a specific component, you can't just set the `--op-space-scale-unit` because the css variables for the scale are already computed and won't be re-computed when you set the scale unit. You can force it to re-compute by redefining the scale. This is why each set of tokens is defined in a scss mixin. `card--condensed` is a great example of how to do this.
 
-```scss
+```css
 .card--condensed {
   @include spacing-scales;
   --rm-space-scale-unit: 0.5rem;
+}
+```
+
+```css
+.font--condensed {
+  @include font-scales;
+  --rm-font-scale-unit: 0.5rem;
 }
 ```
 

--- a/src/stories/4_ScaleOverriding.stories.mdx
+++ b/src/stories/4_ScaleOverriding.stories.mdx
@@ -4,7 +4,13 @@ import { Meta } from '@storybook/addon-docs'
 
 # Scale Overriding
 
-If you want to change the font or spacing scale within the context of a specific component, you can't just set the `--rm-space-scale-unit` because the css variables for the scale are already computed and won't be re-computed when you set the scale unit. You can force it to re-compute by redefining the scale. This is why each set of tokens is defined in a scss mixin. `card--condensed` is a great example of how to do this.
+There are multiple scales in Optics. Unit Scales exist to allow adjusting font and spacing values. Color Scales exist to provide semantically named color variables with corresponding "on" values that strive to maintain contrast when used on an element with the matching color.
+
+## Unit Scale Overriding
+
+A Unit Scale is defined for both font sizes and spacing variables. All values are multiplied by their respective units which default as `1rem` (equivelant to `10px`)
+
+If you want to change the font or spacing scale globally, or within the context of a specific component, you can't just set the `--op-space-scale-unit` because the css variables for the scale are already computed and won't be re-computed when you set the scale unit. You can force it to re-compute by redefining the scale. This is why each set of tokens is defined in a scss mixin. `card--condensed` is a great example of how to do this.
 
 ```scss
 .card--condensed {
@@ -12,3 +18,36 @@ If you want to change the font or spacing scale within the context of a specific
   --rm-space-scale-unit: 0.5rem;
 }
 ```
+
+## Color Scale Overriding
+
+There are multiple reasons your application may need to override the provided color scales. You may set a primary color that doesn't work well with the default semantic color scale provided. Your design may want to stray from the present plus or minus stops.
+
+Regardless of the reason, you can customize and override each scale like the following example:
+
+```css
+@mixin color-varieties {
+  --op-color-primary-h: 164;
+  --op-color-primary-s: 100%;
+  --op-color-primary-l: 50%;
+}
+@mixin primary-semantic-scale-overrides {
+  // Main Scale
+  --op-color-primary-plus-two: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 49%);
+  --op-color-primary-plus-one: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 43%);
+  // On Scale
+  --op-color-primary-on-plus-two: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 15%);
+  --op-color-primary-on-plus-one: var(--op-color-white);
+}
+:root {
+  @include primary-semantic-scale-overrides;
+}
+```
+
+<!---
+  Add These in the Color Support Task #140
+--op-color-primary-on-plus-two-alt: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 5%);
+--op-color-primary-on-plus-one-alt: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 92%);
+-->
+
+You can override as many or as few variables or scales as your application needs.

--- a/src/stories/Font/Font.js
+++ b/src/stories/Font/Font.js
@@ -28,3 +28,11 @@ export const createLineHeight = ({ lineHeight = 'base' }) => {
   `
   return wrapper
 }
+
+export const createFontSize = ({ size = 'medium' }) => {
+  const element = document.createElement('p')
+  const sizeStyle = `var(--rm-font-${size})`
+  element.innerText = `Font Size Demo using: ${sizeStyle}`
+  element.style.fontSize = sizeStyle
+  return element
+}

--- a/src/stories/Font/Font.js
+++ b/src/stories/Font/Font.js
@@ -8,3 +8,11 @@ export const createFontFamily = ({ family = 'Noto Sans' }) => {
 
   return element
 }
+
+export const createFontWeight = ({ weight = 'normal' }) => {
+  const element = document.createElement('p')
+  const weightStyle = `var(--rm-font-weight-${weight})`
+  element.innerText = `Font Weight Demo using: ${weightStyle}`
+  element.style.fontWeight = weightStyle
+  return element
+}

--- a/src/stories/Font/Font.js
+++ b/src/stories/Font/Font.js
@@ -16,3 +16,15 @@ export const createFontWeight = ({ weight = 'normal' }) => {
   element.style.fontWeight = weightStyle
   return element
 }
+
+export const createLineHeight = ({ lineHeight = 'base' }) => {
+  const wrapper = document.createElement('div')
+
+  const lineHeightStyle = `var(--rm-line-height-${lineHeight})`
+  wrapper.innerHTML = `
+    <p style='line-height: ${lineHeightStyle};'>First Line</p>
+    <p style='line-height: ${lineHeightStyle};'>Line Height Demo using: ${lineHeightStyle}</p>
+    <p style='line-height: ${lineHeightStyle};'>Second Line</p>
+  `
+  return wrapper
+}

--- a/src/stories/Font/Font.js
+++ b/src/stories/Font/Font.js
@@ -1,0 +1,10 @@
+export const createFontFamily = ({ family = 'Noto Sans' }) => {
+  const element = document.createElement('p')
+  element.innerText = `Font Family Demo using: ${family}`
+
+  if (family === 'Tilt Neon') {
+    element.className = 'font-family-demo--alternative'
+  }
+
+  return element
+}

--- a/src/stories/Font/FontFamily.mdx
+++ b/src/stories/Font/FontFamily.mdx
@@ -1,0 +1,44 @@
+import { Primary, ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+
+# Font Family
+
+The Font Family token can be used to change the font used when displaying text
+
+The default font is set to Noto Sans which is loaded via the Google Fonts CDN
+
+```css
+@import 'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap';
+```
+
+## Usage
+
+This token can be applied like:
+
+```css
+font-family: var(--rm-font-family);
+```
+
+## Available tokens and their definitions
+
+```css
+--rm-font-family: 'Noto Sans', 'Noto Serif', sans-serif;
+```
+
+## Custom Font
+
+If you want to change the font used by default, you can add a new font import to your stylesheet and apply it using the font family token.
+
+**Note** Not all fonts have the same baseline line height. This can cause alignment issues in your text that may require you to adjust the default line height tokens TODO: Link to them here
+
+```css
+@import 'https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap';
+
+:root {
+  --rm-font-family: 'Tilt Neon', sans-serif;
+}
+```
+
+## Playground
+
+<Primary />
+<ArgsTable of="." story="^" />

--- a/src/stories/Font/FontFamily.mdx
+++ b/src/stories/Font/FontFamily.mdx
@@ -9,6 +9,7 @@ The default font is set to Noto Sans which is loaded via the Google Fonts CDN
 
 ```css
 @import 'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap';
+@import 'https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap';
 ```
 
 ## Usage
@@ -16,7 +17,9 @@ The default font is set to Noto Sans which is loaded via the Google Fonts CDN
 This token can be applied like:
 
 ```css
-font-family: var(--rm-font-family);
+html {
+  font-family: var(--rm-font-family);
+}
 ```
 
 ## Available tokens and their definitions

--- a/src/stories/Font/FontFamily.mdx
+++ b/src/stories/Font/FontFamily.mdx
@@ -1,4 +1,5 @@
 import { Primary, ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+import LinkTo from '@storybook/addon-links/react'
 
 # Font Family
 
@@ -28,7 +29,7 @@ font-family: var(--rm-font-family);
 
 If you want to change the font used by default, you can add a new font import to your stylesheet and apply it using the font family token.
 
-**Note** Not all fonts have the same baseline line height. This can cause alignment issues in your text that may require you to adjust the default line height tokens TODO: Link to them here
+**Note** Not all fonts have the same baseline line height. This can cause alignment issues in your text that may require you to adjust the default line height tokens. See <LinkTo kind="tokens-typography-line-height--base#custom-font">Adjusting Line Heights</LinkTo>.
 
 ```css
 @import 'https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap';

--- a/src/stories/Font/FontSize.mdx
+++ b/src/stories/Font/FontSize.mdx
@@ -1,0 +1,39 @@
+import { Primary, ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+import LinkTo from '@storybook/addon-links/react'
+
+# Font Size
+
+Font Size tokens can be used to change the size of text.
+
+## Usage
+
+These tokens can be applied like:
+
+```css
+font-size: var(--rm-font-large);
+```
+
+## Available tokens and their definitions
+
+```css
+--rm-font-x-small: calc(var(--rm-font-scale-unit) * 1.2); // 12px
+--rm-font-small: calc(var(--rm-font-scale-unit) * 1.4); // 14px
+--rm-font-medium: calc(var(--rm-font-scale-unit) * 1.6); // 16px
+--rm-font-large: calc(var(--rm-font-scale-unit) * 1.8); // 18px
+--rm-font-x-large: calc(var(--rm-font-scale-unit) * 2.4); // 24px
+--rm-font-2x-large: calc(var(--rm-font-scale-unit) * 2.8); // 28px
+--rm-font-3x-large: calc(var(--rm-font-scale-unit) * 3.2); // 32px
+--rm-font-4x-large: calc(var(--rm-font-scale-unit) * 3.6); // 36px
+--rm-font-5x-large: calc(var(--rm-font-scale-unit) * 4.8); // 48px
+```
+
+The scale unit is also defined and can be used for <LinkTo kind="overview-scale-overriding--page#unit-scale-overriding">scale overriding</LinkTo>
+
+```css
+--rm-font-scale-unit: 1rem; // 10px;
+```
+
+## Playground
+
+<Primary />
+<ArgsTable of="." story="^" />

--- a/src/stories/Font/FontWeight.mdx
+++ b/src/stories/Font/FontWeight.mdx
@@ -1,0 +1,35 @@
+import { Primary, ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+import LinkTo from '@storybook/addon-links/react'
+
+# Font Weight
+
+Font Weight tokens can be used to change the font weight of text.
+
+**Note** When using a <LinkTo kind="tokens-typography-font-family--default#custom-font">custom font</LinkTo>, some of these weights may use the closes available weight since not all fonts support all font weights.
+
+## Usage
+
+These tokens can be applied like:
+
+```css
+font-weight: var(--rm-font-weight-bold);
+```
+
+## Available tokens and their definitions
+
+```css
+--rm-font-weight-thin: 100;
+--rm-font-weight-extra-light: 200;
+--rm-font-weight-light: 300;
+--rm-font-weight-normal: 400;
+--rm-font-weight-medium: 500;
+--rm-font-weight-semi-bold: 600;
+--rm-font-weight-bold: 700;
+--rm-font-weight-extra-bold: 800;
+--rm-font-weight-black: 900;
+```
+
+## Playground
+
+<Primary />
+<ArgsTable of="." story="^" />

--- a/src/stories/Font/LineHeight.mdx
+++ b/src/stories/Font/LineHeight.mdx
@@ -1,0 +1,46 @@
+import { Primary, ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+import LinkTo from '@storybook/addon-links/react'
+
+# Line Height
+
+Line height tokens can be used to change the line height of text.
+
+{/* **Note** Not all fonts have the same baseline line height. This can cause alignment issues in your text that may require you to adjust the default line height tokens */}
+
+## Usage
+
+These tokens can be applied like:
+
+```css
+line-height: var(--rm-line-height-dense);
+```
+
+## Available tokens and their definitions
+
+```css
+--rm-line-height-none: 0;
+--rm-line-height-densest: 1;
+--rm-line-height-denser: 1.15;
+--rm-line-height-dense: 1.3;
+--rm-line-height-base: 1.5;
+--rm-line-height-loose: 1.6;
+--rm-line-height-looser: 1.7;
+--rm-line-height-loosest: 1.8;
+```
+
+## Custom Font
+
+**Note** When using a <LinkTo kind="tokens-typography-font-family--default#custom-font">custom font</LinkTo>.
+
+Not all fonts have the same baseline line height. This can cause alignment issues in your text that may require you to adjust the default line height tokens. You can do that by overriding these tokens
+
+```css
+:root {
+  --rm-line-height-looser: 3;
+}
+```
+
+## Playground
+
+<Primary />
+<ArgsTable of="." story="^" />

--- a/src/stories/FontFamily.stories.js
+++ b/src/stories/FontFamily.stories.js
@@ -1,0 +1,31 @@
+import { createFontFamily } from './Font/Font.js'
+import FontFamilyDocs from './Font/FontFamily.mdx'
+
+export default {
+  title: 'Tokens/Typography/Font Family',
+  argTypes: {
+    family: {
+      control: { type: 'select' },
+      options: ['Noto Sans', 'Tilt Neon'],
+    },
+  },
+  parameters: {
+    docs: {
+      page: FontFamilyDocs,
+    },
+  },
+}
+
+const Template = ({ family, ...args }) => {
+  return createFontFamily({ family, ...args })
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  family: 'Noto Sans',
+}
+
+export const Alternate = Template.bind({})
+Alternate.args = {
+  family: 'Tilt Neon',
+}

--- a/src/stories/FontSize.stories.js
+++ b/src/stories/FontSize.stories.js
@@ -1,0 +1,36 @@
+import { createFontSize } from './Font/Font.js'
+import FontSizeDocs from './Font/FontSize.mdx'
+
+export default {
+  title: 'Tokens/Typography/Font Size',
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['x-small', 'small', 'medium', 'large', 'x-large', '2x-large', '3x-large', '4x-large', '5x-large'],
+    },
+  },
+  parameters: {
+    docs: {
+      page: FontSizeDocs,
+    },
+  },
+}
+
+const Template = ({ size, ...args }) => {
+  return createFontSize({ size, ...args })
+}
+
+export const Small = Template.bind({})
+Small.args = {
+  size: 'small',
+}
+
+export const Medium = Template.bind({})
+Medium.args = {
+  size: 'medium',
+}
+
+export const Large = Template.bind({})
+Large.args = {
+  size: 'large',
+}

--- a/src/stories/FontWeight.stories.js
+++ b/src/stories/FontWeight.stories.js
@@ -1,0 +1,31 @@
+import { createFontWeight } from './Font/Font.js'
+import FontWeightDocs from './Font/FontWeight.mdx'
+
+export default {
+  title: 'Tokens/Typography/Font Weight',
+  argTypes: {
+    weight: {
+      control: { type: 'select' },
+      options: ['thin', 'extra-light', 'light', 'normal', 'semi-bold', 'bold', 'extra-bold', 'black'],
+    },
+  },
+  parameters: {
+    docs: {
+      page: FontWeightDocs,
+    },
+  },
+}
+
+const Template = ({ weight, ...args }) => {
+  return createFontWeight({ weight, ...args })
+}
+
+export const Normal = Template.bind({})
+Normal.args = {
+  weight: 'normal',
+}
+
+export const Bold = Template.bind({})
+Bold.args = {
+  weight: 'bold',
+}

--- a/src/stories/LetterSpacing.stories.js
+++ b/src/stories/LetterSpacing.stories.js
@@ -2,7 +2,7 @@ import { createLetterSpacing } from './LetterSpacing/LetterSpacing.js'
 import LetterSpacingDocs from './LetterSpacing/LetterSpacing.mdx'
 
 export default {
-  title: 'Tokens/Letter Spacing',
+  title: 'Tokens/Typography/Letter Spacing',
   argTypes: {
     spacing: {
       control: { type: 'select' },

--- a/src/stories/LineHeight.stories.js
+++ b/src/stories/LineHeight.stories.js
@@ -1,0 +1,31 @@
+import { createLineHeight } from './Font/Font.js'
+import LineHeightDocs from './Font/LineHeight.mdx'
+
+export default {
+  title: 'Tokens/Typography/Line Height',
+  argTypes: {
+    lineHeight: {
+      control: { type: 'select' },
+      options: ['none', 'densest', 'denser', 'dense', 'base', 'loose', 'looser', 'loosest'],
+    },
+  },
+  parameters: {
+    docs: {
+      page: LineHeightDocs,
+    },
+  },
+}
+
+const Template = ({ lineHeight, ...args }) => {
+  return createLineHeight({ lineHeight, ...args })
+}
+
+export const Base = Template.bind({})
+Base.args = {
+  lineHeight: 'base',
+}
+
+export const Loosest = Template.bind({})
+Loosest.args = {
+  lineHeight: 'loosest',
+}


### PR DESCRIPTION
## Task

#101 

## Why?

In addition to adding the clarifying note,  we want to add documentation for all the typography related tokens that currently exist.

## What Changed

- [X] Add Scale Overriding Documentation
- [X] Add Font Family Documentation
- [X] Add Font Weight Documentation
- [X] Add Font Size Documentation
- [X] Add Line Height Documentation
- [X] Add links between line height and font family for note on adjusting

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you run linters?~~
- ~~Have you run prettier?~~
- ~~Have you tried building the css?~~
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="1073" alt="Screenshot 2023-02-28 at 11 51 52 PM" src="https://user-images.githubusercontent.com/5957102/222047924-00f36cf4-d173-41b5-b9ba-55181f9dca50.png">
<img width="1066" alt="Screenshot 2023-02-28 at 11 51 55 PM" src="https://user-images.githubusercontent.com/5957102/222047926-7eef6120-f6af-417f-9f1f-8c2af3c3e467.png">
<img width="1106" alt="Screenshot 2023-02-28 at 11 52 01 PM" src="https://user-images.githubusercontent.com/5957102/222047928-8bc0d329-813b-4e3f-9595-aabb27f263a9.png">
<img width="1046" alt="Screenshot 2023-02-28 at 11 52 09 PM" src="https://user-images.githubusercontent.com/5957102/222047929-e555c542-74cd-446c-a781-bce7429f807c.png">
<img width="1090" alt="Screenshot 2023-02-28 at 11 52 15 PM" src="https://user-images.githubusercontent.com/5957102/222047930-848041f4-5a81-497d-8f68-9af5fb5b2d13.png">
