### PR TITLE
Add confirm dialog with documentation

### DIFF
--- a/.storybook/documentation.scss
+++ b/.storybook/documentation.scss
@@ -81,3 +81,11 @@
     }
   }
 }
+
+.confirm-dialog-wrapper--demo {
+  position: unset;
+
+  .confirm-dialog-wrapper__backdrop {
+    position: unset;
+  }
+}

--- a/src/components/confirm-dialog.scss
+++ b/src/components/confirm-dialog.scss
@@ -1,0 +1,78 @@
+%confirm-dialog-wrapper-global {
+  position: fixed;
+  z-index: var(--op-z-index-dialog);
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  overflow: hidden;
+  align-items: center;
+  justify-content: center;
+  outline: 0;
+  visibility: hidden;
+
+  .confirm-dialog-wrapper__backdrop {
+    position: fixed;
+    z-index: var(--op-z-index-dialog-backdrop);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: var(--op-color-black);
+    opacity: 0;
+    transition: var(--op-transition-modal);
+    visibility: hidden;
+  }
+
+  &.confirm-dialog-wrapper--active {
+    visibility: visible;
+
+    .confirm-dialog-wrapper__backdrop {
+      opacity: 0.5;
+      visibility: visible;
+    }
+  }
+}
+
+%confirm-dialog-global {
+  --op-confirm-dialog-width: 40rem;
+
+  z-index: var(--op-z-index-dialog-content);
+  width: var(--op-confirm-dialog-width);
+  border-radius: var(--op-radius-medium);
+  background-color: var(--op-color-background);
+  box-shadow: var(--op-border-all) var(--op-border-color);
+  color: var(--op-color-on-background);
+  contain: paint;
+  font-size: var(--op-font-medium);
+  line-height: var(--op-line-height-base);
+
+  .confirm-dialog__header,
+  .confirm-dialog__body,
+  .confirm-dialog__footer {
+    padding: var(--op-space-medium);
+  }
+
+  .confirm-dialog__header {
+    font-size: var(--op-font-large);
+    font-weight: var(--op-font-weight-semi-bold);
+  }
+
+  .confirm-dialog__body {
+    box-shadow: var(--op-border-all) var(--op-border-color);
+  }
+
+  .confirm-dialog__footer {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+.confirm-dialog-wrapper {
+  @extend %confirm-dialog-wrapper-global;
+}
+
+.confirm-dialog {
+  @extend %confirm-dialog-global;
+}

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -3,6 +3,7 @@
 @import 'button';
 @import 'button_group';
 @import 'card';
+@import 'confirm-dialog';
 @import 'flash';
 @import 'form';
 @import 'icon';

--- a/src/stories/ConfirmDialog.stories.js
+++ b/src/stories/ConfirmDialog.stories.js
@@ -1,0 +1,32 @@
+import { createConfirmDialog } from './ConfirmDialog/ConfirmDialog.js'
+import ConfirmDialogDocs from './ConfirmDialog/ConfirmDialog.mdx'
+
+export default {
+  title: 'Components/Confirm Dialog',
+  argTypes: {
+    title: { control: 'text' },
+    message: { control: 'text' },
+  },
+  parameters: {
+    docs: {
+      page: ConfirmDialogDocs,
+    },
+  },
+}
+
+const Template = ({ title, ...args }) => {
+  return createConfirmDialog({ title, ...args })
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  title: 'Confirm Title',
+  message: 'Are you sure you want to delete this?',
+}
+
+export const Inline = Template.bind({})
+Inline.args = {
+  title: 'Confirm Title',
+  message: 'Are you sure you want to delete this?',
+  inlineDemo: true,
+}

--- a/src/stories/ConfirmDialog/ConfirmDialog.js
+++ b/src/stories/ConfirmDialog/ConfirmDialog.js
@@ -1,0 +1,25 @@
+export const createConfirmDialog = ({
+  title,
+  message,
+  inlineDemo = false
+}) => {
+  const element = document.createElement('div')
+
+  element.innerHTML = `
+<div class="confirm-dialog-wrapper confirm-dialog-wrapper--active ${inlineDemo ? 'confirm-dialog-wrapper--demo' : ''}">
+  <div class="confirm-dialog-wrapper__backdrop"></div>
+  <div class="confirm-dialog">
+    <div class='confirm-dialog__header'>${title}</div>
+    <div class='confirm-dialog__body'>
+      ${message}
+    </div>
+    <div class='confirm-dialog__footer'>
+      <button class="btn">Cancel</button>
+      <button class='btn-delete'>Yes, I'm Sure</button>
+    </div>
+  </div>
+</div>
+`
+
+  return element
+}

--- a/src/stories/ConfirmDialog/ConfirmDialog.js
+++ b/src/stories/ConfirmDialog/ConfirmDialog.js
@@ -1,8 +1,9 @@
 export const createConfirmDialog = ({ title, message, inlineDemo = false }) => {
   const element = document.createElement('div')
 
+  element.classList = `confirm-dialog-wrapper confirm-dialog-wrapper--active ${inlineDemo ? 'confirm-dialog-wrapper--demo' : ''}`
+
   element.innerHTML = `
-<div class="confirm-dialog-wrapper confirm-dialog-wrapper--active ${inlineDemo ? 'confirm-dialog-wrapper--demo' : ''}">
   <div class="confirm-dialog-wrapper__backdrop"></div>
   <div class="confirm-dialog">
     <div class='confirm-dialog__header'>${title}</div>
@@ -14,7 +15,6 @@ export const createConfirmDialog = ({ title, message, inlineDemo = false }) => {
       <button class='btn-delete'>Yes, I'm Sure</button>
     </div>
   </div>
-</div>
 `
 
   return element

--- a/src/stories/ConfirmDialog/ConfirmDialog.js
+++ b/src/stories/ConfirmDialog/ConfirmDialog.js
@@ -1,8 +1,4 @@
-export const createConfirmDialog = ({
-  title,
-  message,
-  inlineDemo = false
-}) => {
+export const createConfirmDialog = ({ title, message, inlineDemo = false }) => {
   const element = document.createElement('div')
 
   element.innerHTML = `

--- a/src/stories/ConfirmDialog/ConfirmDialog.js
+++ b/src/stories/ConfirmDialog/ConfirmDialog.js
@@ -1,7 +1,9 @@
 export const createConfirmDialog = ({ title, message, inlineDemo = false }) => {
   const element = document.createElement('div')
 
-  element.classList = `confirm-dialog-wrapper confirm-dialog-wrapper--active ${inlineDemo ? 'confirm-dialog-wrapper--demo' : ''}`
+  element.classList = `confirm-dialog-wrapper confirm-dialog-wrapper--active ${
+    inlineDemo ? 'confirm-dialog-wrapper--demo' : ''
+  }`
 
   element.innerHTML = `
   <div class="confirm-dialog-wrapper__backdrop"></div>

--- a/src/stories/ConfirmDialog/ConfirmDialog.mdx
+++ b/src/stories/ConfirmDialog/ConfirmDialog.mdx
@@ -1,0 +1,83 @@
+import { ArgsTable, Canvas, Story } from '@storybook/addon-docs'
+
+# Confirm Dialog
+
+The Confirm Dialog classes can be used for styling a custom alert or confirm dialog. This can be used alongside [Turbo Confirm](https://github.com/RoleModel/turbo-confirm) to achieve custom Confirm Dialogs using Turbo
+
+
+## Default
+
+`.confirm-dialog-wrapper` Wraps the entire dialog.
+
+`.confirm-dialog-wrapper--active` Allows the dialog to live on your page always, but only show if the class is present.
+
+`.confirm-dialog-wrapper__backdrop` Provides the dark background to help focus on the dialog.
+
+`.confirm-dialog` Provides the actual Dialog styling which is constructed similar to the card component.
+
+  * `.confirm-dialog__header`
+  * `.confirm-dialog__body`
+  * `.confirm-dialog__footer`
+
+<Canvas withToolbar>
+  <Story id="components-confirm-dialog--inline" />
+</Canvas>
+
+## Overriding Confirm Dialog styles
+
+The classes are built on sass placeholder selectors https://sass-lang.com/documentation/style-rules/placeholder-selectors
+
+This allows classes to share the same behavior. You can modify all dialogs behavior by overriding the `%confirm-dialog-wrapper-global` and `%confirm-dialog-global` placeholder selectors and setting any properties:
+
+```css
+%confirm-dialog-wrapper-global {
+  z-index: 200;
+}
+
+%confirm-dialog-global {
+  background-color: red;
+}
+```
+
+## Custom Confirm Dialog
+
+Your application may need a custom dialog. To add one, just follow this template:
+
+```css
+.confirm-dialog-wrapper {
+  @extend %confirm-dialog-wrapper-global;
+
+  .confirm-dialog-wrapper__backdrop {
+
+  }
+
+  &.confirm-dialog-wrapper--active {
+    .confirm-dialog-wrapper__backdrop {
+    }
+  }
+}
+
+.confirm-dialog-{name} {
+  @extend %confirm-dialog-global;
+
+  .confirm-dialog__header,
+  .confirm-dialog__body,
+  .confirm-dialog__footer {
+    padding:
+  }
+
+  .confirm-dialog__header {
+    font-size:
+    font-weight:
+  }
+
+  .confirm-dialog__body {
+    box-shadow:
+  }
+
+  .confirm-dialog__footer {
+    display:
+    justify-content:
+  }
+}
+```

--- a/src/stories/ConfirmDialog/ConfirmDialog.mdx
+++ b/src/stories/ConfirmDialog/ConfirmDialog.mdx
@@ -4,7 +4,6 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs'
 
 The Confirm Dialog classes can be used for styling a custom alert or confirm dialog. This can be used alongside [Turbo Confirm](https://github.com/RoleModel/turbo-confirm) to achieve custom Confirm Dialogs using Turbo
 
-
 ## Default
 
 `.confirm-dialog-wrapper` Wraps the entire dialog.
@@ -15,9 +14,9 @@ The Confirm Dialog classes can be used for styling a custom alert or confirm dia
 
 `.confirm-dialog` Provides the actual Dialog styling which is constructed similar to the card component.
 
-  * `.confirm-dialog__header`
-  * `.confirm-dialog__body`
-  * `.confirm-dialog__footer`
+- `.confirm-dialog__header`
+- `.confirm-dialog__body`
+- `.confirm-dialog__footer`
 
 <Canvas withToolbar>
   <Story id="components-confirm-dialog--inline" />


### PR DESCRIPTION
## Why?

The dialog was designed in figma, but needed to be implemented.

## What Changed

- [X] Add Confirm Dialog similar to modal

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="757" alt="Screenshot 2023-05-02 at 6 35 58 PM" src="https://user-images.githubusercontent.com/5957102/235800268-3a490a74-6e3f-4d6e-9e64-da185d217d8f.png">
