### PR TITLE
Button Focus Fix

### DIFF
--- a/src/addons/tom-select.scss
+++ b/src/addons/tom-select.scss
@@ -68,7 +68,7 @@
   &.multi.input-active {
     .#{$select-ns}-control {
       // Highly specific SVG data image for the dropdown arrow.
-      background-image: var(--op-form-dropdown-arrow);
+      background-image: var(--op-encoded-images-dropdown-arrow);
       background-position-x: calc(100% - var(--op-space-small));
       background-position-y: center;
       background-repeat: no-repeat;

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -126,8 +126,6 @@
   }
 
   // Focus State
-  &:focus,
-  &:focus-within,
   &:focus-visible {
     background-color: var(--op-color-neutral-plus-eight);
     box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
@@ -156,8 +154,6 @@
     }
 
     // Borderless + Focus State
-    &:focus,
-    &:focus-within,
     &:focus-visible {
       background-color: var(--op-color-primary-plus-eight);
       box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
@@ -189,8 +185,6 @@
   }
 
   // Focus State
-  &:focus,
-  &:focus-within,
   &:focus-visible {
     background-color: var(--op-color-primary-base);
     box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
@@ -219,8 +213,6 @@
     }
 
     // Borderless + Focus State
-    &:focus,
-    &:focus-within,
     &:focus-visible {
       background-color: var(--op-color-primary-plus-eight);
       box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
@@ -252,8 +244,6 @@
   }
 
   // Focus State
-  &:focus,
-  &:focus-within,
   &:focus-visible {
     background-color: var(--op-color-alerts-danger-base);
     box-shadow: var(--__op-btn-inner-focus) var(--op-color-alerts-danger-plus-two),
@@ -284,8 +274,6 @@
   }
 
   // Focus State
-  &:focus,
-  &:focus-within,
   &:focus-visible {
     background-color: var(--op-color-alerts-warning-base);
     box-shadow: var(--__op-btn-inner-focus) var(--op-color-alerts-warning-plus-two),
@@ -314,8 +302,6 @@
     }
 
     // Borderless + Focus State
-    &:focus,
-    &:focus-within,
     &:focus-visible {
       background-color: var(--op-color-alerts-warning-plus-eight);
       box-shadow: var(--__op-btn-inner-focus) var(--op-color-alerts-warning-plus-two),

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -10,10 +10,6 @@
   // Private API (don't touch these)
   --__op-btn-height: var(--_op-btn-height-large);
   --__op-btn-font-size: var(--_op-btn-font-large);
-  --__op-btn-inner-focus: inset 0 0 0 var(--op-border-width-large);
-  --__op-btn-outer-focus: 0 0 0 var(--op-border-width-x-large);
-  --__op-btn-inner-focus-color: var(--op-color-primary-plus-two);
-  --__op-btn-outer-focus-color: var(--op-color-primary-plus-five);
 
   display: inline-flex;
   min-height: var(--__op-btn-height);
@@ -104,9 +100,6 @@
 .btn {
   @extend %btn-global;
 
-  --__op-btn-inner-focus-color: var(--op-color-primary-plus-two);
-  --__op-btn-outer-focus-color: var(--op-color-primary-plus-five);
-
   background-color: var(--op-color-neutral-plus-eight);
   box-shadow: inset var(--op-border-all) var(--op-color-neutral-plus-four);
   color: var(--op-color-neutral-on-plus-eight);
@@ -128,8 +121,7 @@
   // Focus State
   &:focus-visible {
     background-color: var(--op-color-neutral-plus-eight);
-    box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
-      var(--__op-btn-outer-focus) var(--op-color-primary-plus-five);
+    box-shadow: var(--op-input-focus-primary);
     color: var(--op-color-neutral-on-plus-eight);
   }
 
@@ -156,8 +148,7 @@
     // Borderless + Focus State
     &:focus-visible {
       background-color: var(--op-color-primary-plus-eight);
-      box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
-        var(--__op-btn-outer-focus) var(--op-color-primary-plus-five);
+      box-shadow: var(--op-input-focus-primary);
       color: var(--op-color-primary-on-plus-eight);
     }
   }
@@ -187,8 +178,7 @@
   // Focus State
   &:focus-visible {
     background-color: var(--op-color-primary-base);
-    box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
-      var(--__op-btn-outer-focus) var(--op-color-primary-plus-five);
+    box-shadow: var(--op-input-focus-primary);
     color: var(--op-color-primary-on-base);
   }
 
@@ -215,8 +205,7 @@
     // Borderless + Focus State
     &:focus-visible {
       background-color: var(--op-color-primary-plus-eight);
-      box-shadow: var(--__op-btn-inner-focus) var(--op-color-primary-plus-two),
-        var(--__op-btn-outer-focus) var(--op-color-primary-plus-five);
+      box-shadow: var(--op-input-focus-primary);
       color: var(--op-color-primary-on-plus-eight);
     }
   }
@@ -246,8 +235,7 @@
   // Focus State
   &:focus-visible {
     background-color: var(--op-color-alerts-danger-base);
-    box-shadow: var(--__op-btn-inner-focus) var(--op-color-alerts-danger-plus-two),
-      var(--__op-btn-outer-focus) var(--op-color-alerts-danger-plus-five);
+    box-shadow: var(--op-input-focus-danger);
     color: var(--op-color-alerts-danger-on-base);
   }
 }
@@ -276,8 +264,7 @@
   // Focus State
   &:focus-visible {
     background-color: var(--op-color-alerts-warning-base);
-    box-shadow: var(--__op-btn-inner-focus) var(--op-color-alerts-warning-plus-two),
-      var(--__op-btn-outer-focus) var(--op-color-alerts-warning-plus-five);
+    box-shadow: var(--op-input-focus-warning);
     color: var(--op-color-alerts-warning-on-base);
   }
 
@@ -304,8 +291,7 @@
     // Borderless + Focus State
     &:focus-visible {
       background-color: var(--op-color-alerts-warning-plus-eight);
-      box-shadow: var(--__op-btn-inner-focus) var(--op-color-alerts-warning-plus-two),
-        var(--__op-btn-outer-focus) var(--op-color-alerts-warning-plus-five);
+      box-shadow: var(--op-input-focus-warning);
       color: var(--op-color-alerts-warning-on-plus-eight);
     }
   }

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -74,11 +74,11 @@
   &:focus-within,
   &:focus-visible,
   &:active {
-    box-shadow: 0 0 0 var(--op-border-width-large) var(--op-color-primary-plus-four), var(--op-input-focus);
+    box-shadow: var(--op-input-focus-primary);
     outline: none;
 
     &:hover:not(:disabled) {
-      box-shadow: 0 0 0 var(--op-border-width-large) var(--op-color-primary-plus-four), var(--op-input-focus);
+      box-shadow: var(--op-input-focus-primary);
     }
   }
 }

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -34,8 +34,10 @@
 %dropdown-arrow {
   padding-right: var(--op-space-3x-large);
   appearance: none;
-  background: var(--op-form-dropdown-arrow) center right no-repeat;
-  background-position-x: calc(100% - ((var(--op-space-3x-large) / 2) - (var(--op-form-dropdown-arrow-width) / 2)));
+  background: var(--op-encoded-images-dropdown-arrow) center right no-repeat;
+  background-position-x: calc(
+    100% - ((var(--op-space-3x-large) / 2) - (var(--op-encoded-images-dropdown-arrow-width) / 2))
+  );
   cursor: pointer;
 }
 

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -194,7 +194,7 @@
   /**
   * @tokens Encoded Images
   */
-  --op-form-dropdown-arrow-width: 1rem; // No way to string interpolate
+  --op-form-dropdown-arrow-width: var(--op-space-scale-unit); // No way to string interpolate
   --op-form-dropdown-arrow: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 7' version='1.1' xmlns='http://www.w3.org/2000/svg' width='10' height='7'%3E%3Cg transform='matrix(0.983953,0,0,1.00934,-9.22679,-3.65885)'%3E%3Cpath fill='%23d1d1d1' d='M9.37727 3.625l5.08154 6.93523L19.54036 3.625'/%3E%3C/g%3E%3C/svg%3E%0A");
 }
 

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -268,9 +268,14 @@
   * @tokens Input Focus
   * @presenter Shadow
   */
-  --op-input-outer-focus: 0 0 0 var(--op-border-width-large) var(--op-color-primary-plus-four);
-  --op-input-inner-focus: inset var(--op-border-all) var(--op-color-primary-minus-three);
-  --op-input-focus: var(--op-input-inner-focus), var(--op-input-outer-focus);
+  --op-input-inner-focus: inset 0 0 0 var(--op-border-width-large);
+  --op-input-outer-focus: 0 0 0 var(--op-border-width-x-large);
+  --op-input-focus-primary: var(--op-input-inner-focus) var(--op-color-primary-plus-two),
+    var(--op-input-outer-focus) var(--op-color-primary-plus-five);
+  --op-input-focus-danger: var(--op-input-inner-focus) var(--op-color-alerts-danger-plus-two),
+    var(--op-input-outer-focus) var(--op-color-alerts-danger-plus-five);
+  --op-input-focus-warning: var(--op-input-inner-focus) var(--op-color-alerts-warning-plus-two),
+    var(--op-input-outer-focus) var(--op-color-alerts-warning-plus-five);
 }
 
 // We use SCSS variables outside the root since support for custom properties / css variables

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -194,8 +194,8 @@
   /**
   * @tokens Encoded Images
   */
-  --op-form-dropdown-arrow-width: var(--op-space-scale-unit); // No way to string interpolate
-  --op-form-dropdown-arrow: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 7' version='1.1' xmlns='http://www.w3.org/2000/svg' width='10' height='7'%3E%3Cg transform='matrix(0.983953,0,0,1.00934,-9.22679,-3.65885)'%3E%3Cpath fill='%23d1d1d1' d='M9.37727 3.625l5.08154 6.93523L19.54036 3.625'/%3E%3C/g%3E%3C/svg%3E%0A");
+  --op-encoded-images-dropdown-arrow-width: var(--op-space-scale-unit); // No way to string interpolate
+  --op-encoded-images-dropdown-arrow: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 7' version='1.1' xmlns='http://www.w3.org/2000/svg' width='10' height='7'%3E%3Cg transform='matrix(0.983953,0,0,1.00934,-9.22679,-3.65885)'%3E%3Cpath fill='%23d1d1d1' d='M9.37727 3.625l5.08154 6.93523L19.54036 3.625'/%3E%3C/g%3E%3C/svg%3E%0A");
 }
 
 @mixin fonts {

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -152,9 +152,6 @@ Your application may need a custom button. To add one, just follow this template
 .btn-{name} {
   @extend %btn-global;
 
-  --__op-btn-inner-focus-color:
-  --__op-btn-outer-focus-color:
-
   background-color:
   box-shadow:
   color:

--- a/src/stories/Tokens/EncodedImage.mdx
+++ b/src/stories/Tokens/EncodedImage.mdx
@@ -17,7 +17,7 @@ It is a data-encoded URI SVG which can be set as a background image and then pos
 These tokens can be applied as a background image and the width for position.
 
 ```css
-background: var(--op-form-dropdown-arrow) center right no-repeat;
+background: var(--op-encoded-images-dropdown-arrow) center right no-repeat;
 ```
 
 ## Available tokens and their definitions

--- a/src/stories/Tokens/Input/InputFocus.mdx
+++ b/src/stories/Tokens/Input/InputFocus.mdx
@@ -12,7 +12,7 @@ Input Focus tokens are used to define a button or form controls focus state.
 These tokens can be applied to anything that uses a box shadow.
 
 ```css
-box-shadow: var(--op-input-focus);
+box-shadow: var(--op-input-focus-primary);
 ```
 
 ## Available tokens and their definitions


### PR DESCRIPTION
## Why?

@zoopmaster pointed out that our focus state was too aggressive on buttons. Rather than show it on click or tab focus, we should show it only on tab (keyboard navigation) focus, but not on click.

https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html

The intent of the focus ring is to replace the natural pointer interaction when not using a direct selection device, such as a mouse, touchpad, pen tablet, or trackball. When using a keyboard or assistive technology you need this visual indication on the screen because the user is not directly pointing to the control itself.

## What Changed

- [X] Remove focus and focus-within rules from button focus states
- [X] Use scale unit token for dropdown arrow width
- [X] Simplify and unify input and button focus shadows

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots


https://github.com/RoleModel/optics/assets/5957102/6ca6ae1b-1985-467a-921f-e95d97a24fad

