### PR TITLE
Fix Documentation Deployment

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs-build # The folder that the build-storybook script generates files.
+          FOLDER: storybook-static # The folder that the build-storybook script generates files.
           CLEAN: true # Automatically remove deleted files from the deploy branch
           TARGET_FOLDER: docs # The folder that we serve our Storybook files from


### PR DESCRIPTION
## Why?

Documentation Deployment was not working.

## What Changed

- [X] Change the folder the deploy script is pointing to. Storybook v7 changged this