### PR TITLE
Addon change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "modern-css-reset": "^1.4.0",
-        "tom-select": "^2.0.0"
+        "modern-css-reset": "^1.4.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -44,6 +43,14 @@
         "stylelint-config-standard-scss": "^6.1.0",
         "stylelint-prettier": "^2.0.0",
         "stylelint-scss": "^4.3.0"
+      },
+      "peerDependencies": {
+        "tom-select": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "tom-select": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2835,6 +2842,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@orchidjs/sifter/-/sifter-1.0.3.tgz",
       "integrity": "sha512-zCZbwKegHytfsPm8Amcfh7v/4vHqTAaOu6xFswBYcn8nznBOuseu6COB2ON7ez0tFV0mKL0nRNnCiZZA+lU9/g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@orchidjs/unicode-variants": "^1.0.4"
       }
@@ -2842,7 +2851,9 @@
     "node_modules/@orchidjs/unicode-variants": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@orchidjs/unicode-variants/-/unicode-variants-1.0.4.tgz",
-      "integrity": "sha512-NvVBRnZNE+dugiXERFsET1JlKZfM5lJDEpSMilKW4bToYJ7pxf0Zne78xyXB2ny2c2aHfJ6WLnz1AaTNHAmQeQ=="
+      "integrity": "sha512-NvVBRnZNE+dugiXERFsET1JlKZfM5lJDEpSMilKW4bToYJ7pxf0Zne78xyXB2ny2c2aHfJ6WLnz1AaTNHAmQeQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@reach/observe-rect": {
       "version": "1.2.0",
@@ -15317,6 +15328,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tom-select/-/tom-select-2.2.2.tgz",
       "integrity": "sha512-igGah1yY6yhrnN2h/Ky8I5muw/nE/YQxIsEZoYu5qaA4bsRibvKto3s8QZZosKpOd0uO8fNYhRfAwgHB4IAYew==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@orchidjs/sifter": "^1.0.3",
         "@orchidjs/unicode-variants": "^1.0.4"
@@ -18210,6 +18223,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@orchidjs/sifter/-/sifter-1.0.3.tgz",
       "integrity": "sha512-zCZbwKegHytfsPm8Amcfh7v/4vHqTAaOu6xFswBYcn8nznBOuseu6COB2ON7ez0tFV0mKL0nRNnCiZZA+lU9/g==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@orchidjs/unicode-variants": "^1.0.4"
       }
@@ -18217,7 +18232,9 @@
     "@orchidjs/unicode-variants": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@orchidjs/unicode-variants/-/unicode-variants-1.0.4.tgz",
-      "integrity": "sha512-NvVBRnZNE+dugiXERFsET1JlKZfM5lJDEpSMilKW4bToYJ7pxf0Zne78xyXB2ny2c2aHfJ6WLnz1AaTNHAmQeQ=="
+      "integrity": "sha512-NvVBRnZNE+dugiXERFsET1JlKZfM5lJDEpSMilKW4bToYJ7pxf0Zne78xyXB2ny2c2aHfJ6WLnz1AaTNHAmQeQ==",
+      "optional": true,
+      "peer": true
     },
     "@reach/observe-rect": {
       "version": "1.2.0",
@@ -27558,6 +27575,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tom-select/-/tom-select-2.2.2.tgz",
       "integrity": "sha512-igGah1yY6yhrnN2h/Ky8I5muw/nE/YQxIsEZoYu5qaA4bsRibvKto3s8QZZosKpOd0uO8fNYhRfAwgHB4IAYew==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@orchidjs/sifter": "^1.0.3",
         "@orchidjs/unicode-variants": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "@RoleModel:registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "modern-css-reset": "^1.4.0",
-    "tom-select": "^2.0.0"
+    "modern-css-reset": "^1.4.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",
@@ -77,5 +76,13 @@
     "stylelint-config-standard-scss": "^6.1.0",
     "stylelint-prettier": "^2.0.0",
     "stylelint-scss": "^4.3.0"
+  },
+  "peerDependencies": {
+    "tom-select": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tom-select": {
+      "optional": true
+    }
   }
 }

--- a/src/addons/tom-select.scss
+++ b/src/addons/tom-select.scss
@@ -1,6 +1,3 @@
-// Core Tom Select Styles
-@import 'tom-select/dist/scss/tom-select';
-
 // By default $select-ns is "ts"
 
 // Design System Overrides

--- a/src/stories/Overview/Addons.mdx
+++ b/src/stories/Overview/Addons.mdx
@@ -13,7 +13,7 @@ Optics provides a few addons for integrating Third-Party tools with your applica
 If your application uses Tom Select, you can import the styles from Tom Select along with the Design Systems tokens applied to it by placing this after importing the base design system.
 
 ```css
-@import '@rolemodel/optics/';
+@import '@rolemodel/optic';
 @import 'tom-select/dist/scss/tom-select';
 
 @import '@rolemodel/optics/dist/scss/addons/tom-select';
@@ -26,5 +26,7 @@ Panel provide styles that are intended to accompany the rails configuration and 
 If your application uses this implementation, you can import the styles via:
 
 ```css
+@import '@rolemodel/optic';
+
 @import '@rolemodel/optics/dist/scss/addons/panel';
 ```

--- a/src/stories/Overview/Addons.mdx
+++ b/src/stories/Overview/Addons.mdx
@@ -13,6 +13,9 @@ Optics provides a few addons for integrating Third-Party tools with your applica
 If your application uses Tom Select, you can import the styles from Tom Select along with the Design Systems tokens applied to it by placing this after importing the base design system.
 
 ```css
+@import '@rolemodel/optics/';
+@import 'tom-select/dist/scss/tom-select';
+
 @import '@rolemodel/optics/dist/scss/addons/tom-select';
 ```
 


### PR DESCRIPTION
## Why?

When this package is installed, it currently also installs Tom Select automatically, even if you are not using the add-on. I wanted to resolve this issue.

## What Changed

In order to fix this, two things needed to happen:

- [X] Change Tom Select to be an optional peer dependency. This means if your project is using Tom Select, when you add Optics, it will warn you if the version is incompatible. If your project does not have Tom Select, Optics will not install it or warn about anything.
- [X] Change the Add-on to not pull in Tom Select itself, but require the application to pull it in. The documentation example on this was updated to reflect. **This is Technically a breaking change, but only if you are using the add-on and it's a two line fix.**

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~