### PR TITLE
Alerts fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15793,9 +15793,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-      "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
@@ -27921,9 +27921,9 @@
       "dev": true
     },
     "vite": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-      "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.17.5",

--- a/src/components/alert.scss
+++ b/src/components/alert.scss
@@ -71,7 +71,8 @@
   }
 }
 
-.alert-danger {
+.alert-danger,
+.alert-alert {
   @extend %alert-global;
 
   background-color: var(--op-color-alerts-danger-plus-eight);

--- a/src/components/alert.scss
+++ b/src/components/alert.scss
@@ -71,6 +71,7 @@
   }
 }
 
+// alert-alert is an alias for alert-danger. See Alert.mdx for reasoning.
 .alert-danger,
 .alert-alert {
   @extend %alert-global;

--- a/src/stories/Components/Alert/Alert.mdx
+++ b/src/stories/Components/Alert/Alert.mdx
@@ -40,6 +40,8 @@ Alert can be used as a standalone component, however, it does have a few depende
 
 `.alert-danger` Provides a danger styled message
 
+`.alert-alert` is an alias for `.alert-danger`. Since RoleModel commonly uses [Rails](https://rubyonrails.org/) to develop projects, adding this alias allows this to be used for flash messages without having to change the default in rails. [Devise](https://github.com/heartcombo/devise) is also commonly used and cannot easily be configured away from this.
+
 <Canvas of={AlertStories.Danger} />
 
 ### Info


### PR DESCRIPTION
## Why?

An issue that was noticed on a few projects was how the Rails convention for flash names was difficult to change and made it hard to work with the alert component.

## What Changed

- [X] Add `alert-alert` as alias for `alert-danger`

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

![Screenshot 2023-06-07 at 2 06 26 PM](https://github.com/RoleModel/optics/assets/5957102/5c3f2c9b-6c93-441a-a084-9ff7ba0275bf)
