### PR TITLE
Breakpoint continuity

### DIFF
--- a/src/core/layout.scss
+++ b/src/core/layout.scss
@@ -21,7 +21,7 @@
 
 .app__content {
   width: 100%;
-  max-width: $breakpoint-medium;
+  max-width: var(--op-breakpoint-medium);
   flex-grow: 1;
   padding: 0 var(--op-space-large);
   margin: 0 auto;

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -64,6 +64,29 @@
   --op-color-alerts-notice-l: 64%;
 }
 
+// Breakpoints are duplicated here for use as variables with calculations and for use in @media queries.
+// We use SCSS variables outside the root since support for custom properties / css variables
+// is not yet available
+// https://drafts.csswg.org/css-env-1/
+// https://bholmes.dev/blog/alternative-to-css-variable-media-queries/
+@mixin breakpoints {
+  /**
+  * @tokens Breakpoints
+  * @presenter Spacing
+  */
+  --op-breakpoint-x-small: 512px; // vertical phone
+  --op-breakpoint-small: 768px; // vertical ipad
+  --op-breakpoint-medium: 1024px; // landscape ipad
+  --op-breakpoint-large: 1280px; // small laptop
+  --op-breakpoint-x-large: 1440px; // medium laptop
+}
+
+$breakpoint-x-small: 512px; // vertical phone
+$breakpoint-small: 768px; // vertical ipad
+$breakpoint-medium: 1024px; // landscape ipad
+$breakpoint-large: 1280px; // small laptop
+$breakpoint-x-large: 1440px; // medium laptop
+
 @mixin border-radius {
   /**
   * @tokens Border Radius
@@ -279,23 +302,12 @@
     var(--op-input-outer-focus) var(--op-color-alerts-warning-plus-five);
 }
 
-// We use SCSS variables outside the root since support for custom properties / css variables
-// is not yet available
-// https://drafts.csswg.org/css-env-1/
-// https://bholmes.dev/blog/alternative-to-css-variable-media-queries/
-
-/**
-* @tokens Breakpoints
-*/
-$breakpoint-x-small: 512px; // vertical phone
-$breakpoint-small: 768px; // vertical ipad
-$breakpoint-medium: 1024px; // landscape ipad
-$breakpoint-large: 1280px; // small laptop
-$breakpoint-x-large: 1440px; // medium laptop
-
 :root {
   // Color HSLs
   @include color-varieties;
+
+  // Breakpoints
+  @include breakpoints;
 
   // Border
   @include border-radius;

--- a/src/core/utilities.scss
+++ b/src/core/utilities.scss
@@ -2,13 +2,13 @@
 
 .container {
   width: 100%;
-  max-width: $breakpoint-medium;
+  max-width: var(--op-breakpoint-medium);
   padding: 0 var(--op-space-large);
   margin: 0 auto;
 }
 
 .container--sm {
-  max-width: $breakpoint-small;
+  max-width: var(--op-breakpoint-small);
 }
 
 .container--md-padding {
@@ -20,7 +20,7 @@
 }
 
 .container--xs {
-  max-width: $breakpoint-x-small;
+  max-width: var(--op-breakpoint-x-small);
 }
 
 // Width Properties

--- a/src/stories/Tokens/Breakpoint.mdx
+++ b/src/stories/Tokens/Breakpoint.mdx
@@ -5,9 +5,14 @@ import { DesignTokenDocBlock } from 'storybook-design-token'
 
 # Breakpoint
 
-Breakpoint tokens are used to define common device sizes for use within media queries.
+Breakpoint tokens are used to define common device sizes for use within media queries or max widths.
 
-We use SCSS variables to define these breakpoints.
+They are implemented in two ways. First as CSS custom properties (css variables) and second as SCSS variables.
+
+The CSS variables can be used like any of the other tokens for things requiring calculations or max widths.
+
+The SCSS variables can be used for media queries.
+
 Custom properties (css variables) currently cannot be used in a media query since they get defined in an element scope (`:root` in our case).
 Media queries exist at the document level and therefore cannot access custom properties.
 
@@ -20,6 +25,10 @@ Media queries exist at the document level and therefore cannot access custom pro
 These tokens can be applied in a media query to create responsive behavior.
 
 ```css
+.small-area {
+  max-width: var(--op-breakpoint-small);
+}
+
 @media (width > $breakpoint-medium) {
   background-color: var(--op-color-primary-base);
   color: var(--op-color-primary-on-base);


### PR DESCRIPTION
## Why?

SCSS variables cannot be used in calc while CSS variables cannot be used in media queries.
In order to use breakpoint values for things like calculations or max widths, we want to add css variable version of the breakpoints  to prevent magic numbers and allow consistent sizing of things.

## What Changed

- [X] Add css variable breakpoints along with docs
- [X] Update usage where able to use css variable versions

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="1072" alt="Screenshot 2023-06-23 at 11 39 25 AM" src="https://github.com/RoleModel/optics/assets/5957102/5c17ca4b-bb42-44fc-b4ed-cfb257923f19">
