### PR TITLE
Select control fix

### DIFF
--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -112,10 +112,12 @@
 %dropdown-arrow {
   padding-right: var(--op-space-3x-large);
   appearance: none;
-  background: var(--op-encoded-images-dropdown-arrow) center right no-repeat;
+  background-image: var(--op-encoded-images-dropdown-arrow);
+  background-position: center right;
   background-position-x: calc(
     100% - ((var(--op-space-3x-large) / 2) - (var(--op-encoded-images-dropdown-arrow-width) / 2))
   );
+  background-repeat: no-repeat;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Why?

@dallasbpeters noticed the Select form control was not using the correct background color. This was due to how the dropdown arrow was being applied.

## What Changed

- [X] Use individual properties to set the dropdown arrow instead of rollup which overrode the background color.

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

If the background was changed, the select wouldn't match other inputs

Before
<img width="1175" alt="Screenshot 2023-06-30 at 11 19 24 AM" src="https://github.com/RoleModel/optics/assets/5957102/b852d392-6434-4c1a-bafb-ed19e0a1be20">

After
<img width="1206" alt="Screenshot 2023-06-30 at 11 21 35 AM" src="https://github.com/RoleModel/optics/assets/5957102/5eb3f22a-b828-464d-a070-793fedc02134">
