### PR TITLE
Toggle Label Fix + Documentation

### DIFF
--- a/src/components/toggle.scss
+++ b/src/components/toggle.scss
@@ -93,6 +93,11 @@
     --__op-toggle-width: var(--_op-toggle-width-large);
     --__op-toggle-height: var(--_op-toggle-height-large);
   }
+
+  // Prevent labels after the toggle being full width
+  & + label {
+    width: fit-content;
+  }
 }
 
 .toggle {


### PR DESCRIPTION
## Why?

As I was building out a Simple form control to utilize the new Toggle Component, I discovered an issue.

## What Changed

- [X] Fix label after toggle
- [ ] Add documentation pointing to RoleModel Rails Simple Form Custom Input

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~Have you updated the dependency graph with any component changes?~~
- [ ] Have you run linters?
- [ ] Have you run prettier?
- [ ] Have you tried building the css?
- [ ] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

Before
<img width="1003" alt="Screenshot 2023-07-02 at 6 36 30 PM" src="https://github.com/RoleModel/optics/assets/5957102/9e3337a6-f6cb-49dd-ba3b-bef8fb6cb143">

After
<img width="1000" alt="Screenshot 2023-07-02 at 6 36 38 PM" src="https://github.com/RoleModel/optics/assets/5957102/68ba5121-eb3b-4674-af4a-122bd2594a0d">
