### PR TITLE
[TR#138] Size Scale

### DIFF
--- a/src/components/accordion.scss
+++ b/src/components/accordion.scss
@@ -1,6 +1,6 @@
 %accordion-global {
   // Public API (allowed to be overridden)
-  --_op-accordion-summary-min-height: calc(var(--op-space-2x-large) + var(--op-space-2x-small));
+  --_op-accordion-summary-min-height: calc(8 * var(--op-size-unit)); // 32px
 
   summary {
     display: grid;

--- a/src/components/avatar.scss
+++ b/src/components/avatar.scss
@@ -7,9 +7,9 @@
   --_op-avatar-outer-border-width: var(--op-border-width-large);
   --_op-avatar-disabled-opacity: var(--op-opacity-disabled);
   --_op-avatar-hover-opacity: var(--op-opacity-overlay);
-  --_op-avatar-size-small: 3.2rem;
-  --_op-avatar-size-medium: 4rem;
-  --_op-avatar-size-large: 5.6rem;
+  --_op-avatar-size-small: calc(8 * var(--op-size-unit)); // 32px
+  --_op-avatar-size-medium: calc(10 * var(--op-size-unit)); // 40px
+  --_op-avatar-size-large: calc(14 * var(--op-size-unit)); // 56px
 
   // Private API (don't touch these)
   --__op-avatar-size: var(--_op-avatar-size-large);

--- a/src/components/confirm-dialog.scss
+++ b/src/components/confirm-dialog.scss
@@ -36,7 +36,7 @@
 
 %confirm-dialog-global {
   // Public API (allowed to be overridden)
-  --_op-confirm-dialog-width: 40rem;
+  --_op-confirm-dialog-width: calc(100 * var(--op-size-unit)); // 400px
 
   z-index: var(--op-z-index-dialog-content);
   width: var(--_op-confirm-dialog-width);

--- a/src/components/modal.scss
+++ b/src/components/modal.scss
@@ -39,8 +39,8 @@
 
 %modal-global {
   // Public API (allowed to be overridden)
-  --_op-modal-width: 56.4rem;
-  --_op-modal-max-height: 50rem;
+  --_op-modal-width: calc(141 * var(--op-size-unit)); // 564px
+  --_op-modal-max-height: calc(125 * var(--op-size-unit)); // 500px
 
   z-index: var(--op-z-index-dialog-content);
   width: var(--_op-modal-width);

--- a/src/components/navbar.scss
+++ b/src/components/navbar.scss
@@ -4,9 +4,7 @@
   --_op-navbar-background-color: var(--op-color-neutral-plus-eight);
   --_op-navbar-text-color: var(--op-color-neutral-on-plus-eight);
   --_op-navbar-border-color: var(--op-color-neutral-plus-four);
-
-  // Height (Will eventually make a size scale that is separate from the space scale)
-  --_op-navbar-brand-height: calc(var(--op-space-3x-large) + var(--op-space-x-small)); // 48px
+  --_op-navbar-brand-height: calc(12 * var(--op-size-unit)); // 48px
 
   // Spacing
   --_op-navbar-horizontal-spacing: var(--op-space-x-large);

--- a/src/components/sidebar.scss
+++ b/src/components/sidebar.scss
@@ -49,12 +49,12 @@
   --_op-sidebar-border-color: var(--op-color-neutral-plus-four);
 
   // Width
-  --_op-sidebar-rail-width: 8.8rem;
-  --_op-sidebar-compact-width: 16.9rem;
-  --_op-sidebar-drawer-width: 21.6rem;
-  --_op-sidebar-rail-brand-width: 7.728rem;
-  --_op-sidebar-compact-brand-width: 9.8rem;
-  --_op-sidebar-drawer-brand-width: 9.8rem;
+  --_op-sidebar-rail-width: calc(22 * var(--op-size-unit)); // 88px
+  --_op-sidebar-compact-width: calc(42 * var(--op-size-unit)); // 168px
+  --_op-sidebar-drawer-width: calc(54 * var(--op-size-unit)); // 216px
+  --_op-sidebar-rail-brand-width: calc(19 * var(--op-size-unit)); // 76px
+  --_op-sidebar-compact-brand-width: calc(24 * var(--op-size-unit)); // 96px
+  --_op-sidebar-drawer-brand-width: calc(24 * var(--op-size-unit)); // 96px
 
   // Spacing
   --_op-sidebar-spacing: calc(var(--op-space-2x-large) + var(--op-space-2x-small));

--- a/src/components/spinner.scss
+++ b/src/components/spinner.scss
@@ -5,10 +5,10 @@
   --_op-spinner-track-width-small: var(--op-border-width-large);
   --_op-spinner-track-width-medium: calc(var(--op-border-width-large) + var(--op-border-width));
   --_op-spinner-track-width-large: var(--op-border-width-x-large);
-  --_op-spinner-diameter-x-small: var(--op-space-x-large);
-  --_op-spinner-diameter-small: var(--op-space-3x-large);
-  --_op-spinner-diameter-medium: calc(var(--op-space-3x-large) + var(--op-space-large));
-  --_op-spinner-diameter-large: var(--op-space-4x-large);
+  --_op-spinner-diameter-x-small: calc(6 * var(--op-size-unit)); // 24px
+  --_op-spinner-diameter-small: calc(10 * var(--op-size-unit)); // 40px
+  --_op-spinner-diameter-medium: calc(15 * var(--op-size-unit)); // 60px
+  --_op-spinner-diameter-large: calc(20 * var(--op-size-unit)); // 80px
   --_op-spinner-animation-duration: 0.8s;
   --_op-spinner-animation-timing-function: linear;
 

--- a/src/components/switch.scss
+++ b/src/components/switch.scss
@@ -1,9 +1,9 @@
 %switch-global {
   // Public API (allowed to be overridden)
-  --_op-switch-height-small: var(--op-space-medium); // 1.6rem
-  --_op-switch-height-large: var(--op-space-x-large); // 2.4rem
-  --_op-switch-width-small: calc(var(--op-space-x-large) + var(--op-space-3x-small)); // 2.6rem
-  --_op-switch-width-large: calc(var(--op-space-3x-large) + var(--op-space-3x-small)); // 4.2rem
+  --_op-switch-height-small: calc(4 * var(--op-size-unit)); // 16px
+  --_op-switch-height-large: calc(6 * var(--op-size-unit)); // 24px
+  --_op-switch-width-small: calc(7 * var(--op-size-unit)); // 28px
+  --_op-switch-width-large: calc(11 * var(--op-size-unit)); // 44px
   --_op-switch-opacity-disabled: var(--op-opacity-disabled);
   --_op-switch-switch-padding: var(--op-space-2x-small);
 

--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -1,9 +1,9 @@
 %table-global {
   // Public API
   // Cells (for height, the appropriate variable is used when using the density modifiers)
-  --_op-table-cell-height-default: calc(var(--op-space-scale-unit) * 4.4);
-  --_op-table-cell-height-comfortable: calc(var(--op-space-scale-unit) * 6.4);
-  --_op-table-cell-height-compact: calc(var(--op-space-scale-unit) * 3.4);
+  --_op-table-cell-height-default: calc(11 * var(--op-size-unit)); // 44px
+  --_op-table-cell-height-comfortable: calc(16 * var(--op-size-unit)); // 64px
+  --_op-table-cell-height-compact: calc(8 * var(--op-size-unit)); // 32px
 
   // Private API
   // These allow for overriding specific padding versions easier.

--- a/src/components/tooltip.scss
+++ b/src/components/tooltip.scss
@@ -1,6 +1,6 @@
 %tooltip-global {
   // Public API
-  --_op-tooltip-max-width: calc(5 * var(--op-space-3x-large));
+  --_op-tooltip-max-width: calc(50 * var(--op-size-unit)); // 200px
   --_op-tooltip-padding: var(--op-space-x-small) var(--op-space-medium);
   --_op-tooltip-background-color: var(--op-color-neutral-minus-max);
   --_op-tooltip-text-color: var(--op-color-neutral-on-minus-max);

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -260,6 +260,14 @@ $breakpoint-x-large: 1440px; // medium laptop
   --op-space-4x-large: calc(var(--op-space-scale-unit) * 8); // 80px
 }
 
+@mixin sizing-scales {
+  /**
+  * @tokens Size Scale
+  * @presenter Spacing
+  */
+  --op-size-unit: 0.4rem; // 4px;
+}
+
 @mixin shadows {
   /**
   * @tokens Shadows
@@ -351,6 +359,7 @@ $breakpoint-x-large: 1440px; // medium laptop
   @include encoded-images;
 
   // Spacing
+  @include sizing-scales;
   @include spacing-scales;
 
   // Shadows

--- a/src/stories/Components/Accordion/Accordion.mdx
+++ b/src/stories/Components/Accordion/Accordion.mdx
@@ -51,6 +51,18 @@ Additional content can be included within the `summary` element in any order. An
 
 <Canvas of={AccordionStories.AdditionalHeaderContent} />
 
+## Accordion API
+
+Styles are built on css variables scoped to the accordion.
+
+Here are the variables that can be customized.
+
+{/* prettier-ignore-start */}
+```css
+--_op-accordion-summary-min-height
+```
+{/* prettier-ignore-end */}
+
 ## Customizing Accordion styles
 
 <div

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -107,17 +107,17 @@ Here are the variables and states used
 {/* prettier-ignore-start */}
 ```css
 // Variable API
---_op-btn-height-small:
---_op-btn-height-medium:
---_op-btn-height-large:
+--_op-btn-height-small
+--_op-btn-height-medium
+--_op-btn-height-large
 
---_op-btn-font-small:
---_op-btn-font-medium:
---_op-btn-font-large:
+--_op-btn-font-small
+--_op-btn-font-medium
+--_op-btn-font-large
 
---_op-btn-padding-small:
---_op-btn-padding-medium:
---_op-btn-padding-large:
+--_op-btn-padding-small
+--_op-btn-padding-medium
+--_op-btn-padding-large
 
 // Different states
 .btn {} // Default behavior

--- a/src/stories/Components/ButtonGroup/ButtonGroup.mdx
+++ b/src/stories/Components/ButtonGroup/ButtonGroup.mdx
@@ -70,3 +70,17 @@ Button Group can be used as a standalone component, however, it does have a few 
 ### Size
 
 <Canvas of={ButtonGroupStories.Size} />
+
+## Button Group API
+
+Styles are built on css variables scoped to the button group.
+
+Here are the variables that can be customized.
+
+{/* prettier-ignore-start */}
+```css
+--op-btn-group-hover-z-index
+--op-btn-group-active-z-index
+--op-btn-group-focus-z-index
+```
+{/* prettier-ignore-end */}

--- a/src/stories/Components/ConfirmDialog/ConfirmDialog.mdx
+++ b/src/stories/Components/ConfirmDialog/ConfirmDialog.mdx
@@ -40,6 +40,18 @@ Confirm Dialog can be used as a standalone component, however, it does have a fe
 
 <Canvas of={ConfirmDialogStories.Inline} />
 
+## Confirm Dialog API
+
+Styles are built on css variables scoped to the confirm dialog.
+
+Here are the variables that can be customized.
+
+{/* prettier-ignore-start */}
+```css
+--_op-confirm-dialog-width
+```
+{/* prettier-ignore-end */}
+
 ## Customizing Confirm Dialog styles
 
 <div

--- a/src/stories/Components/Divider/Divider.mdx
+++ b/src/stories/Components/Divider/Divider.mdx
@@ -61,13 +61,13 @@ Here are the variables that can be customized.
 
 {/* prettier-ignore-start */}
 ```css
---_op-divider-vertical-min-height:
---_op-divider-height-small:
---_op-divider-height-medium:
---_op-divider-height-large:
---_op-divider-padding-small:
---_op-divider-padding-medium:
---_op-divider-padding-large:
+--_op-divider-vertical-min-height
+--_op-divider-height-small
+--_op-divider-height-medium
+--_op-divider-height-large
+--_op-divider-padding-small
+--_op-divider-padding-medium
+--_op-divider-padding-large
 ```
 {/* prettier-ignore-end */}
 

--- a/src/stories/Components/Form/Form.mdx
+++ b/src/stories/Components/Form/Form.mdx
@@ -135,6 +135,32 @@ See [MDN's documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/:inde
 
 <Canvas of={FormGroupStories.IndeterminateCheckbox} />
 
+## Form API
+
+Styles are built on css variables scoped to the form elements.
+
+Here are the variables that can be customized.
+
+{/* prettier-ignore-start */}
+```css
+// form-control-global
+--_op-form-control-height-small
+--_op-form-control-height-medium
+--_op-form-control-height-large
+--_op-form-control-font-small
+--_op-form-control-font-medium
+--_op-form-control-font-large
+
+// form-control-input-global
+--_op-form-control-opacity-disabled
+
+// form-control-inline-global
+--_op-form-control-height-small
+--_op-form-control-height-medium
+--_op-form-control-height-large
+```
+{/* prettier-ignore-end */}
+
 ## Customizing Form styles
 
 <div

--- a/src/stories/Components/Modal/Modal.mdx
+++ b/src/stories/Components/Modal/Modal.mdx
@@ -125,6 +125,27 @@ cancelButton.addEventListener('click', () => {
 })
 ```
 
+## Modal API
+
+Styles are built on css variables scoped to the modal.
+
+Here are the variables that can be customized.
+
+{/* prettier-ignore-start */}
+```css
+// modal-wrapper-global
+--_op-modal-backdrop-active-opacity
+
+// modal-global
+--_op-modal-width
+--_op-modal-max-height
+
+// dialog.modal::backdrop
+--op-color-black
+--_op-modal-backdrop-active-opacity
+```
+{/* prettier-ignore-end */}
+
 ## Customizing Modal styles
 
 <div

--- a/src/stories/Components/Navbar/Navbar.mdx
+++ b/src/stories/Components/Navbar/Navbar.mdx
@@ -77,17 +77,17 @@ Here are the variables that can be customized.
 ```css
 // Public API
 // Normal
---_op-navbar-background-color:
---_op-navbar-text-color:
---_op-navbar-border-color:
+--_op-navbar-background-color
+--_op-navbar-text-color
+--_op-navbar-border-color
 
 // Height
---_op-navbar-brand-height:
+--_op-navbar-brand-height
 
 // Spacing
---_op-navbar-horizontal-spacing:
---_op-navbar-content-spacing:
---_op-navbar-content-item-spacing:
+--_op-navbar-horizontal-spacing
+--_op-navbar-content-spacing
+--_op-navbar-content-item-spacing
 ```
 {/* prettier-ignore-end */}
 

--- a/src/stories/Components/Sidebar/Sidebar.mdx
+++ b/src/stories/Components/Sidebar/Sidebar.mdx
@@ -124,26 +124,26 @@ Here are the variables used
 ```css
 // Public API
 // Normal
---_op-sidebar-background-color:
---_op-sidebar-text-color:
---_op-sidebar-border-color:
+--_op-sidebar-background-color
+--_op-sidebar-text-color
+--_op-sidebar-border-color
 
 // Width
---_op-sidebar-rail-width:
---_op-sidebar-compact-width:
---_op-sidebar-drawer-width:
---_op-sidebar-rail-brand-width:
---_op-sidebar-compact-brand-width:
---_op-sidebar-drawer-brand-width:
+--_op-sidebar-rail-width
+--_op-sidebar-compact-width
+--_op-sidebar-drawer-width
+--_op-sidebar-rail-brand-width
+--_op-sidebar-compact-brand-width
+--_op-sidebar-drawer-brand-width
 
 // Spacing
---_op-sidebar-spacing:
---_op-sidebar-brand-spacing:
---_op-sidebar-content-spacing:
---_op-sidebar-content-item-spacing:
+--_op-sidebar-spacing
+--_op-sidebar-brand-spacing
+--_op-sidebar-content-spacing
+--_op-sidebar-content-item-spacing
 
 // Animation
---_op-sidebar-transition:
+--_op-sidebar-transition
 ```
 
 ## Customizing Sidebar styles

--- a/src/stories/Components/Spinner/Spinner.mdx
+++ b/src/stories/Components/Spinner/Spinner.mdx
@@ -71,18 +71,18 @@ Here are the variables that can be customized.
 
 {/* prettier-ignore-start */}
 ```css
-  --_op-spinner-indicator-color:
-  --_op-spinner-track-color:
-  --_op-spinner-track-width-x-small:
-  --_op-spinner-track-width-small:
-  --_op-spinner-track-width-medium:
-  --_op-spinner-track-width-large:
-  --_op-spinner-diameter-x-small:
-  --_op-spinner-diameter-small:
-  --_op-spinner-diameter-medium:
-  --_op-spinner-diameter-large:
-  --_op-spinner-animation-duration:
-  --_op-spinner-animation-timing-function:
+  --_op-spinner-indicator-color
+  --_op-spinner-track-color
+  --_op-spinner-track-width-x-small
+  --_op-spinner-track-width-small
+  --_op-spinner-track-width-medium
+  --_op-spinner-track-width-large
+  --_op-spinner-diameter-x-small
+  --_op-spinner-diameter-small
+  --_op-spinner-diameter-medium
+  --_op-spinner-diameter-large
+  --_op-spinner-animation-duration
+  --_op-spinner-animation-timing-function
 ```
 {/* prettier-ignore-end */}
 

--- a/src/stories/Components/Switch/Switch.mdx
+++ b/src/stories/Components/Switch/Switch.mdx
@@ -63,12 +63,12 @@ Here are the variables that can be customized.
 
 {/* prettier-ignore-start */}
 ```css
---_op-switch-height-small:
---_op-switch-height-large:
---_op-switch-width-small:
---_op-switch-width-large:
---_op-switch-opacity-disabled:
---_op-switch-switch-padding:
+--_op-switch-height-small
+--_op-switch-height-large
+--_op-switch-width-small
+--_op-switch-width-large
+--_op-switch-opacity-disabled
+--_op-switch-switch-padding
 ```
 {/* prettier-ignore-end */}
 

--- a/src/stories/Components/Table/Table.mdx
+++ b/src/stories/Components/Table/Table.mdx
@@ -106,9 +106,9 @@ Here are the variables used
 
 ```css
 // Variable API
---_op-table-cell-padding-default:
---_op-table-cell-padding-comfortable:
---_op-table-cell-padding-compact:
+--_op-table-cell-padding-default
+--_op-table-cell-padding-comfortable
+--_op-table-cell-padding-compact
 ```
 
 ## Customizing Table styles

--- a/src/stories/Components/Tooltip/Tooltip.mdx
+++ b/src/stories/Components/Tooltip/Tooltip.mdx
@@ -79,6 +79,25 @@ Tooltips have a maximum width and will wrap text if it is too long.
 
 <Canvas of={TooltipStories.LotsOfText} />
 
+## Tooltip API
+
+Styles are built on css variables scoped to the tooltip.
+
+Here are the variables that can be customized.
+
+{/* prettier-ignore-start */}
+```css
+--_op-tooltip-max-width
+--_op-tooltip-padding
+--_op-tooltip-background-color
+--_op-tooltip-text-color
+--_op-tooltip-arrow-size
+--_op-tooltip-tooltip-offset
+--_op-tooltip-tooltip-radius
+--_op-tooltip-tooltip-font-size
+```
+{/* prettier-ignore-end */}
+
 ## Customizing Tooltip styles
 
 <div
@@ -92,20 +111,10 @@ Tooltips have a maximum width and will wrap text if it is too long.
 
 The tooltip classes are built on a [sass placeholder selector](https://sass-lang.com/documentation/style-rules/placeholder-selectors)
 
-Tooltips has an API for Customizing the styles of all tooltips easily.
-
-This allows multiple classes to share the same behavior. You can modify all tooltip behavior by overriding the `%tooltip-global` placeholder selector and setting any properties:
+This allows multiple classes to share the same behavior. You can modify all tooltip behavior by overriding the `%toltip-global` placeholder selector and setting any properties:
 
 ```css
 %tooltip-global {
-  --_op-tooltip-max-width
-  --_op-tooltip-padding:
-  --_op-tooltip-background-color:
-  --_op-tooltip-text-color:
-  --_op-tooltip-arrow-size:
-  --_op-tooltip-tooltip-offset:
-  --_op-tooltip-tooltip-radius:
-  --_op-tooltip-tooltip-font-size:
 }
 ```
 

--- a/src/stories/Overview/ScaleOverriding.mdx
+++ b/src/stories/Overview/ScaleOverriding.mdx
@@ -26,6 +26,13 @@ If you want to change the font or spacing scale globally, or within the context 
 }
 ```
 
+```css
+.size--condensed {
+  @include size-scales;
+  --op-size-unit: 0.2rem;
+}
+```
+
 ## Color Scale Overriding
 
 There are multiple reasons your application may need to override the provided color scales. You may set a primary color that doesn't work well with the default semantic color scale provided. Your design may want to stray from the present plus or minus stops.

--- a/src/stories/Tokens/Sizing.mdx
+++ b/src/stories/Tokens/Sizing.mdx
@@ -1,0 +1,25 @@
+import { Meta } from '@storybook/addon-docs'
+import { DesignTokenDocBlock } from 'storybook-design-token'
+import LinkTo from '@storybook/addon-links/react'
+
+<Meta title="Tokens/Sizing" />
+
+# Size
+
+The Size token enables creating scalable widths and heights for your application. It is meant to be used in a `calc` expression with whole numbers. This ensures any sizes you create will be a multiple of 4px.
+
+## Usage
+
+These tokens can be applied like:
+
+```css
+height: calc(11 * var(--op-size-unit)); // 44px
+/* Or */
+width: calc(54 * var(--op-size-unit)); // 216px
+```
+
+## Available tokens and their definitions
+
+<DesignTokenDocBlock categoryName="Size Scale" viewType="card" />
+
+The size unit can be overridden if you want to change the scale or size basis. This can be done at a component level as well [scale overriding](?path=/docs/overview-scale-overriding--docs#unit-scale-overriding)

--- a/src/stories/Tokens/Spacing.mdx
+++ b/src/stories/Tokens/Spacing.mdx
@@ -6,7 +6,7 @@ import LinkTo from '@storybook/addon-links/react'
 
 # Spacing Size
 
-Spacing Size tokens can be used for a wide variety of cases. The can be used for margin, padding, width, height, gap, and anything else that uses pixel values.
+The Spacing Size tokens enable creating scalable spaces for your application. They can be used for margin, padding, gap, and anything else that is intended for spacing.
 
 ## Usage
 
@@ -18,8 +18,6 @@ margin-left: var(--op-space-small);
 padding-top: var(--op-space-medium);
 /* Or */
 gap: var(--op-space-large);
-/* Or */
-width: var(--op-space-4x-large);
 ```
 
 ## Available tokens and their definitions


### PR DESCRIPTION
## Task

[TR #138](https://trello.com/c/Ye1eKd1m/138-add-size-scale)

## Why?

Similar to the space scale, but instead of being for padding, margin, and gap, these would be for width and height.

For almost all cases (unless there is a good justification), sizes should be divisible by 4.

## What Changed

- [X] Update existing documentation to have consistent API explanations
- [X] Add size scale and update components to use it
- [X] Add documentation for size scale

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you updated the dependency graph with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="1268" alt="Screenshot 2023-07-26 at 12 08 16 PM" src="https://github.com/RoleModel/optics/assets/5957102/e5e6943e-d4d3-45cd-848c-b0b7bdebe317">
