### PR TITLE
[TR#137] Opacity Tokens

### DIFF
--- a/src/components/avatar.scss
+++ b/src/components/avatar.scss
@@ -6,7 +6,7 @@
   --_op-avatar-inner-border-width: calc(var(--op-border-width) + var(--op-border-width-large));
   --_op-avatar-outer-border-width: var(--op-border-width-large);
   --_op-avatar-disabled-opacity: var(--op-opacity-disabled);
-  --_op-avatar-hover-opacity: var(--op-opacity-hover);
+  --_op-avatar-hover-opacity: var(--op-opacity-overlay);
   --_op-avatar-size-small: 3.2rem;
   --_op-avatar-size-medium: 4rem;
   --_op-avatar-size-large: 5.6rem;

--- a/src/components/avatar.scss
+++ b/src/components/avatar.scss
@@ -5,8 +5,8 @@
   --_op-avatar-outer-border-color: var(--op-color-neutral-base);
   --_op-avatar-inner-border-width: calc(var(--op-border-width) + var(--op-border-width-large));
   --_op-avatar-outer-border-width: var(--op-border-width-large);
-  --_op-avatar-disabled-opacity: 0.4;
-  --_op-avatar-hover-opacity: 0.2;
+  --_op-avatar-disabled-opacity: var(--op-opacity-disabled);
+  --_op-avatar-hover-opacity: var(--op-opacity-hover);
   --_op-avatar-size-small: 3.2rem;
   --_op-avatar-size-medium: 4rem;
   --_op-avatar-size-large: 5.6rem;

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -72,7 +72,7 @@
   // Disabled Modifier
   &.btn--disabled,
   &:disabled {
-    opacity: 0.44;
+    opacity: var(--op-opacity-disabled);
     pointer-events: none;
     -webkit-user-select: none; /* stylelint-disable property-no-vendor-prefix */
     user-select: none;

--- a/src/components/confirm-dialog.scss
+++ b/src/components/confirm-dialog.scss
@@ -14,7 +14,7 @@
     z-index: var(--op-z-index-dialog-backdrop);
     background: var(--op-color-black);
     inset: 0;
-    opacity: 0;
+    opacity: var(--op-opacity-none);
     transition: var(--op-transition-modal);
     visibility: hidden;
   }
@@ -23,12 +23,12 @@
     visibility: visible;
 
     .confirm-dialog {
-      opacity: 1;
+      opacity: var(--op-opacity-full);
       transform: scale(1);
     }
 
     .confirm-dialog-wrapper__backdrop {
-      opacity: 0.5;
+      opacity: var(--op-opacity-half);
       visibility: visible;
     }
   }
@@ -47,7 +47,7 @@
   contain: paint;
   font-size: var(--op-font-medium);
   line-height: var(--op-line-height-base);
-  opacity: 0;
+  opacity: var(--op-opacity-none);
   transform: scale(0.7);
   transition: var(--op-transition-modal);
 

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -33,7 +33,7 @@
 
 %form-control-input-global {
   // Public API (allowed to be overridden)
-  --_op-form-control-opacity-disabled: 0.44;
+  --_op-form-control-opacity-disabled: var(--op-opacity-disabled);
 
   // Private API (don't touch these)
   --__op-form-control-border-color: var(--op-color-neutral-plus-four);

--- a/src/components/modal.scss
+++ b/src/components/modal.scss
@@ -1,6 +1,6 @@
 %modal-wrapper-global {
   // Public API (allowed to be overridden)
-  --_op-modal-backdrop-active-opacity: 0.5;
+  --_op-modal-backdrop-active-opacity: var(--op-opacity-half);
 
   position: fixed;
   z-index: var(--op-z-index-dialog);
@@ -17,7 +17,7 @@
     z-index: var(--op-z-index-dialog-backdrop);
     background: var(--op-color-black);
     inset: 0;
-    opacity: 0;
+    opacity: var(--op-opacity-none);
     transition: var(--op-transition-modal);
     visibility: hidden;
   }
@@ -26,7 +26,7 @@
     visibility: visible;
 
     .modal {
-      opacity: 1;
+      opacity: var(--op-opacity-full);
       transform: scale(1);
     }
 
@@ -51,7 +51,7 @@
   contain: paint;
   font-size: var(--op-font-medium);
   line-height: var(--op-line-height-base);
-  opacity: 0;
+  opacity: var(--op-opacity-none);
   transform: scale(0.7);
   transition: var(--op-transition-modal);
 
@@ -95,7 +95,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 @keyframes show-backdrop {
   from {
-    opacity: 0;
+    opacity: var(--op-opacity-none);
   }
 
   to {
@@ -109,7 +109,7 @@
   }
 
   to {
-    opacity: 0;
+    opacity: var(--op-opacity-none);
   }
 }
 
@@ -124,6 +124,8 @@ dialog.modal {
     // The Dialog backdrop does not inheret from :root so these need to be duplicated here.
     --op-color-black: hsl(0deg 0% 0%);
     --_op-modal-backdrop-active-opacity: 0.5;
+    --op-opacity-none: 0;
+    --op-opacity-full: 1;
 
     animation: show-backdrop 300ms ease-in;
     background: var(--op-color-black);
@@ -131,17 +133,17 @@ dialog.modal {
   }
 
   &[open] {
-    opacity: 1;
+    opacity: var(--op-opacity-full);
     transform: scale(1);
   }
 
   &.modal--closing {
-    opacity: 0;
+    opacity: var(--op-opacity-none);
     transform: scale(0.7);
 
     &::backdrop {
       animation: hide-backdrop 300ms ease-in;
-      opacity: 0;
+      opacity: var(--op-opacity-none);
     }
   }
 }

--- a/src/components/switch.scss
+++ b/src/components/switch.scss
@@ -4,7 +4,7 @@
   --_op-switch-height-large: var(--op-space-x-large); // 2.4rem
   --_op-switch-width-small: calc(var(--op-space-x-large) + var(--op-space-3x-small)); // 2.6rem
   --_op-switch-width-large: calc(var(--op-space-3x-large) + var(--op-space-3x-small)); // 4.2rem
-  --_op-switch-opacity-disabled: 0.4;
+  --_op-switch-opacity-disabled: var(--op-opacity-disabled);
   --_op-switch-switch-padding: var(--op-space-2x-small);
 
   // Private API (don't touch these)

--- a/src/components/tab.scss
+++ b/src/components/tab.scss
@@ -11,7 +11,7 @@
   --_op-tab-padding-large: var(--op-space-x-small) var(--op-space-medium) var(--op-space-small) var(--op-space-medium);
   --_op-tab-indicator-width-small: var(--op-border-width-large);
   --_op-tab-indicator-width-large: var(--op-border-width-x-large);
-  --_op-tab-disabled-opacity: 0.4;
+  --_op-tab-disabled-opacity: var(--op-opacity-disabled);
 
   // Private API
   --__op-tab-font-size: var(--_op-tab-font-large);

--- a/src/components/tooltip.scss
+++ b/src/components/tooltip.scss
@@ -13,7 +13,7 @@
 
   &::before,
   &::after {
-    opacity: 0;
+    opacity: var(--op-opacity-none);
     transition: var(--op-transition-tooltip);
     visibility: hidden;
   }
@@ -48,7 +48,7 @@
   &:hover {
     &::before,
     &::after {
-      opacity: 1;
+      opacity: var(--op-opacity-full);
       visibility: visible;
     }
   }

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -70,7 +70,7 @@
   * @presenter Opacity
   */
   --op-opacity-none: 0;
-  --op-opacity-hover: 0.2;
+  --op-opacity-overlay: 0.2;
   --op-opacity-disabled: 0.4;
   --op-opacity-half: 0.5;
   --op-opacity-full: 1;

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -64,6 +64,18 @@
   --op-color-alerts-notice-l: 64%;
 }
 
+@mixin opacities {
+  /**
+  * @tokens Opacities
+  * @presenter Opacity
+  */
+  --op-opacity-none: 0;
+  --op-opacity-hover: 0.2;
+  --op-opacity-disabled: 0.4;
+  --op-opacity-half: 0.5;
+  --op-opacity-full: 1;
+}
+
 // Breakpoints are duplicated here for use as variables with calculations and for use in @media queries.
 // We use SCSS variables outside the root since support for custom properties / css variables
 // is not yet available
@@ -311,6 +323,7 @@ $breakpoint-x-large: 1440px; // medium laptop
 :root {
   // Color HSLs
   @include color-varieties;
+  @include opacities;
 
   // Breakpoints
   @include breakpoints;

--- a/src/stories/Tokens/Opacity.mdx
+++ b/src/stories/Tokens/Opacity.mdx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/addon-docs'
+import { DesignTokenDocBlock } from 'storybook-design-token'
+
+<Meta title="Tokens/Opacity" />
+
+# Opacity
+
+Opacity tokens can be used to create a faded or disabled effect on any element.
+
+## Usage
+
+These tokens can be applied as opacities.
+
+```css
+opacity: var(--op-opacity-disabled);
+// or
+opacity: var(--op-opacity-full);
+```
+
+## Available tokens and their definitions
+
+<DesignTokenDocBlock categoryName="Opacities" viewType="card" />


### PR DESCRIPTION
## Task

[TR #137](https://trello.com/c/nRAf2fPR/137-add-global-opacity-tokens)

## Why?

Things like disabled or potentially hover opacity are currently being duplicated in things like tab, avatar, and button.

These should be made consistent.

## What Changed

- [X] Add scale and docs
- [X] Use scale in components

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you updated the dependency graph with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="1039" alt="Screenshot 2023-07-26 at 12 22 19 PM" src="https://github.com/RoleModel/optics/assets/5957102/0d33747f-d9d0-4538-9a56-54835a185e00">
