### PR TITLE
[TR#140] Dropdown Encoded Image

### DIFF
--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -218,8 +218,8 @@ $breakpoint-x-large: 1440px; // medium laptop
   /**
   * @tokens Encoded Images
   */
-  --op-encoded-images-dropdown-arrow-width: var(--op-space-scale-unit); // No way to string interpolate
-  --op-encoded-images-dropdown-arrow: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 7' version='1.1' xmlns='http://www.w3.org/2000/svg' width='10' height='7'%3E%3Cg transform='matrix(0.983953,0,0,1.00934,-9.22679,-3.65885)'%3E%3Cpath fill='%23d1d1d1' d='M9.37727 3.625l5.08154 6.93523L19.54036 3.625'/%3E%3C/g%3E%3C/svg%3E%0A");
+  --op-encoded-images-dropdown-arrow-width: calc(1.2 * var(--op-space-scale-unit)); // 12px No way to string interpolate
+  --op-encoded-images-dropdown-arrow: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik02IDguMzc1MDFMMCAyLjM3NTAxTDEuNCAwLjk3NTAwNkw2IDUuNTc1MDFMMTAuNiAwLjk3NTAwNkwxMiAyLjM3NTAxTDYgOC4zNzUwMVoiIGZpbGw9IiMwQTBBMEIiLz4KPC9zdmc+Cg==');
 }
 
 @mixin fonts {

--- a/src/core/tokens/dark_mode_tokens.scss
+++ b/src/core/tokens/dark_mode_tokens.scss
@@ -446,6 +446,10 @@
   --op-shadow-x-large: 0 8px 12px hsl(0deg 0% 0% / 15%), 0 4px 4px hsl(0deg 0% 0% / 30%);
 }
 
+@mixin encoded-images {
+  --op-encoded-images-dropdown-arrow: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9IiNmZmYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik02IDguMzc1MDFMMCAyLjM3NTAxTDEuNCAwLjk3NTAwNkw2IDUuNTc1MDFMMTAuNiAwLjk3NTAwNkwxMiAyLjM3NTAxTDYgOC4zNzUwMVoiIGZpbGw9IiNmZmYiLz4KPC9zdmc+Cg==');
+}
+
 @mixin all-tokens-dark {
   @include primary-semantic-scale-dark;
   @include neutral-semantic-scale-dark;
@@ -456,6 +460,7 @@
   @include alerts-notice-semantic-scale-dark;
 
   @include shadows-dark;
+  @include encoded-images;
 }
 
 // Follow system preference unless forced to light


### PR DESCRIPTION
## Task

[TR #140](https://trello.com/c/FIewEKNw/140-update-encoded-images-dropdown-arrow-to-reflect-figma-arrow-style)

## Why?

We should update the --op-encoded-images-dropdown-arrow token value to reflect what is in figma

## What Changed

- [X] Update encoded image to reflect Figma
- [X] Add dark mode override to set color correctly

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- ~~Have you updated the docs with any component changes?~~
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="303" alt="Screenshot 2023-07-26 at 3 15 47 PM" src="https://github.com/RoleModel/optics/assets/5957102/29b1cb49-f1b4-4901-a9d3-c8bb5825c647">
<img width="350" alt="Screenshot 2023-07-26 at 3 15 44 PM" src="https://github.com/RoleModel/optics/assets/5957102/05cd18db-277d-4e01-8f50-9494d5e727c6">
