### PR TITLE
[TR#136] Remove warning + no border state for button

### DIFF
--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -275,32 +275,4 @@
     box-shadow: var(--op-input-focus-warning);
     color: var(--op-color-alerts-warning-on-base);
   }
-
-  // Borderless State
-  &.btn--no-border {
-    background-color: transparent;
-    box-shadow: none;
-    color: var(--op-color-alerts-warning-on-plus-max);
-
-    // Borderless + Active State
-    &.btn--active {
-      background-color: var(--op-color-alerts-warning-plus-five);
-      box-shadow: inset var(--op-border-all) var(--op-color-alerts-warning-plus-three);
-      color: var(--op-color-alerts-warning-on-plus-five);
-    }
-
-    // Borderless + Hover State
-    &:hover {
-      background-color: var(--op-color-alerts-warning-plus-eight);
-      box-shadow: inset var(--op-border-all) var(--op-color-alerts-warning-plus-five);
-      color: var(--op-color-alerts-warning-on-plus-eight);
-    }
-
-    // Borderless + Focus State
-    &:focus-visible {
-      background-color: var(--op-color-alerts-warning-plus-eight);
-      box-shadow: var(--op-input-focus-warning);
-      color: var(--op-color-alerts-warning-on-plus-eight);
-    }
-  }
 }

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -58,6 +58,8 @@ Button can be used as a standalone component, however, it does have a few depend
 
 `.btn--no-border` This is a modifier which can be used with all button classes except delete. It provides a button with no border, but the same sizing and adapts it's color to all the btn variations.
 
+Note: `.btn-delete` and `.btn-warning` do not support the `.btn--no-border` modifier. Borderless warning or delete buttons is not considered a good pattern and can easily lead to confusion so it has been disabled.
+
 <Canvas of={ButtonStories.NoBorder} />
 
 ### Disabled


### PR DESCRIPTION
## Task

[TR #136](https://trello.com/c/0dsQb9qy/136-remove-no-border-warning-variant-modifier-combo)

## Why?

This is not a combo designers recommend and should never be used. Our code shouldn’t allow for this.
The delete button is already preventing its combo in this regard so we should update Warning to do the same.

## What Changed

- [X] Remove no border state for warning button

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~
