### PR TITLE
[TR#142] Safari Mobile Form Control Bug

### DIFF
--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -45,6 +45,7 @@
   padding: var(--op-space-2x-small) var(--op-space-x-small) var(--op-space-2x-small) var(--op-space-small);
   border: none;
   border-radius: var(--op-radius-medium);
+  appearance: none;
   background-color: var(--op-color-neutral-plus-eight);
   box-shadow: var(--op-border-all) var(--__op-form-control-border-color);
   color: var(--op-color-neutral-on-plus-eight);


### PR DESCRIPTION
## Task

[TR #142](https://trello.com/c/H7jNSxJE)

## Why?

Box shadows on Form Controls on Safari Mobile were not rendering correctly.

![image](https://github.com/RoleModel/optics/assets/5957102/f207f345-4bdc-48f4-a9be-3c896b6603dd)

## What Changed

- [X] Add appearance none to form control

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you updated the dependency graph with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

![image](https://github.com/RoleModel/optics/assets/5957102/36482170-f7ff-4da4-9217-f80d7d3a32a6)