### PR TITLE
[TR#145] adds transition-tooltip to base_tokens

### DIFF
--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -216,6 +216,7 @@ $breakpoint-x-large: 1440px; // medium laptop
   --op-transition-sidebar: all 200ms ease-in-out;
   --op-transition-modal: all 300ms ease-in;
   --op-transition-panel: right 400ms ease-in;
+  --op-transition-tooltip: all 300ms ease-in 300ms;
 }
 
 @mixin animations {


### PR DESCRIPTION
## Task

[TR#145](https://trello.com/c/tRhN8ZwW/145-transition-tooltip-token-was-missing)

## Why?

`tooltip.scss` calls for `--op-transition-tooltip` but it was not in `base_tokens.scss`. This PR fixes that. 

## What Changed

What changed in this PR?

- [ ] adds `--op-transition-tooltip: all 300ms ease-in 300ms;`

## Sanity Check

~- [ ] Have you updated any usage of changed tokens?~
~- [ ] Have you updated the docs with any component changes?~
~- [ ] Have you updated the dependency graph with any component changes?~
- [x] Have you run linters?
- [x] Have you run prettier?
- [x] Have you tried building the css?
- [x] Have you tried building storybook?
~- [ ] Do you need to update the package version?~

![Screenshot 2023-09-14 at 8 30 00 AM](https://github.com/RoleModel/optics/assets/91672/5cb64bb4-8f97-4910-9dc4-a974d93a3825)
