### PR TITLE
[TR#144] Hide still-visible checkbox on Firefox

### DIFF
--- a/src/components/switch.scss
+++ b/src/components/switch.scss
@@ -15,11 +15,12 @@
 
   position: relative;
   display: flex;
+  align-items: center;
 
   input {
     width: 0;
     height: 0;
-    margin-right: calc(-1 * var(--op-space-2x-small));
+    margin-right: calc(-1 * var(--op-space-x-small));
 
     &:disabled + label {
       cursor: not-allowed;


### PR DESCRIPTION
## Task

[TR #144](https://trello.com/c/puTaCcXF/144-firefox-does-not-hide-the-checkbox-even-if-size-is-explicitly-set-to-zero)

## Why?

The checkbox was still visible on Firefox despite explicit size declarations. This hides it completely.

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you updated the dependency graph with any component changes?~~
- [x] Have you run linters?
- [x] Have you run prettier?
- [x] Have you tried building the css?
- [x] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="598" alt="image" src="https://github.com/RoleModel/optics/assets/88258994/5f5374e3-c1c1-4fd8-9fa1-209810f96a3f">

