### PR TITLE
[TR#148] Hide checkbox input when disabled

### DIFF
--- a/src/components/switch.scss
+++ b/src/components/switch.scss
@@ -22,6 +22,10 @@
     height: 0;
     margin-right: calc(-1 * var(--op-space-x-small));
 
+    &:disabled {
+      visibility: hidden;
+    }
+
     &:disabled + label {
       cursor: not-allowed;
       opacity: var(--_op-switch-opacity-disabled);


### PR DESCRIPTION
## Task

[TR #148](https://trello.com/c/g79GpkR3/148-switch-control-shows-the-actual-checkbox-input-behind-the-switch-when-disabled)

## Why?

The checkbox in the switch control is finicky and can’t be hidden entirely, so it appeared when we lower the opacity for the disabled state. This fixes this.

## What Changed

What changed in this PR?

- [x] Hide switch input when disabled

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you updated the dependency graph with any component changes?~~
- [x] Have you run linters?
- [x] Have you run prettier?
- [x] Have you tried building the css?
- [x] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

<img width="154" alt="image" src="https://github.com/RoleModel/optics/assets/88258994/d4ee2753-3fd0-4bf5-acfb-d5ffb95cc2d7">
