### PR TITLE
[TR#147] Sensible file input styles

### DIFF
--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -155,6 +155,28 @@
     @extend %form-control-inline-global;
   }
 
+  &[type='file'] {
+    padding-block: 0;
+
+    &::file-selector-button {
+      @extend %btn-global;
+
+      --__op-btn-height: var(--_op-btn-height-small);
+      --__op-btn-font-size: var(--_op-btn-font-small);
+      --__op-btn-padding: var(--_op-btn-padding-small);
+
+      border: none;
+      background-color: var(--op-color-neutral-plus-eight);
+      box-shadow: inset var(--op-border-all) var(--op-color-neutral-plus-four);
+      color: var(--op-color-neutral-on-plus-eight);
+      margin-block: calc((var(--__op-form-control-height) / 2) - (var(--__op-btn-height) / 2));
+    }
+
+    &.form-control--small::file-selector-button {
+      --__op-btn-height: calc(var(--_op-btn-height-small) - var(--op-space-x-small));
+    }
+  }
+
   // Disabled State
   &:disabled {
     cursor: not-allowed;

--- a/src/stories/Components/Form/Input.stories.js
+++ b/src/stories/Components/Form/Input.stories.js
@@ -8,7 +8,7 @@ export default {
   argTypes: {
     type: {
       control: { type: 'select' },
-      options: ['Text', 'Number', 'Email', 'Password', 'Tel', 'Checkbox', 'Radio', 'Color', 'Date'],
+      options: ['Text', 'Number', 'Email', 'Password', 'Tel', 'Checkbox', 'Radio', 'Color', 'Date', 'File'],
     },
     size: {
       control: { type: 'select' },


### PR DESCRIPTION
## Task

[TR #147](https://trello.com/c/YLEBlwc8/147-form-control-of-type-file)

## Why?

@zoopmaster noticed that inputs with type set to file were not being styled correctly. This remedies that!

## What Changed

- [X] Add sensible style for input of type file
- [X] Add option to docs playground

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

Before:
<img width="399" alt="Screenshot 2023-09-27 at 3 02 41 PM" src="https://github.com/RoleModel/optics/assets/5957102/37c6cc17-cd06-4581-9ce6-3e17c6270a61">

After:
<img width="326" alt="Screenshot 2023-09-27 at 2 56 49 PM" src="https://github.com/RoleModel/optics/assets/5957102/d2cdf688-649a-4e6d-ab2b-ee09fb4d8669">
<img width="371" alt="Screenshot 2023-09-27 at 2 56 52 PM" src="https://github.com/RoleModel/optics/assets/5957102/44948ba3-b0f8-44d4-a443-779c36482540">
<img width="350" alt="Screenshot 2023-09-27 at 2 56 55 PM" src="https://github.com/RoleModel/optics/assets/5957102/4ec1f922-305a-4971-986c-183bc1eaf358">
<img width="404" alt="Screenshot 2023-09-27 at 2 56 59 PM" src="https://github.com/RoleModel/optics/assets/5957102/2af13fa1-0fba-4bb8-ae15-fa86cdd86402">
<img width="380" alt="Screenshot 2023-09-27 at 2 57 08 PM" src="https://github.com/RoleModel/optics/assets/5957102/976817a6-2544-433e-8526-0ee74167d46e">
