### PR TITLE
Fix accordion arrow showing in safari

### DIFF
--- a/src/components/accordion.scss
+++ b/src/components/accordion.scss
@@ -10,6 +10,12 @@
     gap: var(--op-space-2x-small);
     grid-template-columns: auto 1fr auto;
 
+    &::marker,
+    &::-webkit-details-marker {
+      display: none;
+      content: '';
+    }
+
     .accordion__label {
       color: var(--op-color-neutral-on-plus-max);
       font-size: var(--op-font-x-small);


### PR DESCRIPTION
## Why?

A bug was discovered where Safari does not show accordions correctly.

## What Changed

- [X] Fix accordion in Safari

## Sanity Check

- ~~Have you updated any usage of changed tokens?~~
- ~~Have you updated the docs with any component changes?~~
- ~~Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~Do you need to update the package version?~~

## Screenshots

Before:
<img width="1118" alt="Screenshot 2023-09-28 at 4 44 35 PM" src="https://github.com/RoleModel/optics/assets/5957102/97b57638-3942-42f8-942f-d37a01e24ea4">


After:
<img width="1310" alt="Screenshot 2023-09-28 at 4 15 33 PM" src="https://github.com/RoleModel/optics/assets/5957102/bf63c233-1c49-4352-b100-1e263963fc4e">
