### PR TITLE
[OP-149] Fix Avatar Squish inside a flex container

### DIFF
--- a/src/components/avatar.scss
+++ b/src/components/avatar.scss
@@ -19,7 +19,9 @@
   display: block;
   overflow: hidden;
   width: var(--__op-avatar-size);
+  min-width: var(--__op-avatar-size);
   height: var(--__op-avatar-size);
+  min-height: var(--__op-avatar-size);
   border-radius: var(--_op-avatar-border-radius);
 
   &::before {


### PR DESCRIPTION
## Why?

When an avatar was used inside a flex container, the width and height would get ignored and the avatar would squish

## What Changed

- [X] Add min width and height to avatar component

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots
Before:
<img width="193" alt="Screenshot 2024-02-02 at 3 13 00 PM" src="https://github.com/RoleModel/optics/assets/5957102/2b8f3212-3054-4d75-a6f5-51f97a54d94e">

After:
<img width="186" alt="Screenshot 2024-02-02 at 3 13 19 PM" src="https://github.com/RoleModel/optics/assets/5957102/5195e269-7ede-484a-85d9-10984fb84243">
