### PR TITLE
[OP-123] Tooltip on disabled Button

### DIFF
--- a/.storybook/documentation.scss
+++ b/.storybook/documentation.scss
@@ -19,6 +19,10 @@ html {
   color: var(--op-color-on-background);
 }
 
+.sbdocs .sb-button-fix button {
+  height: 0;
+}
+
 // Allow the "Show Code" button to appear above the footer in examples.
 .docs-story div:last-child {
   z-index: 1;

--- a/src/stories/Components/Tooltip/Tooltip.mdx
+++ b/src/stories/Components/Tooltip/Tooltip.mdx
@@ -39,6 +39,23 @@ Tooltip can be used as a standalone component, however, it does have a few depen
 @import '@rolemodel/optics/dist/scss/components/tooltip';
 ```
 
+## Note on usage with Button
+
+There are cases when you might want to put a tooltip on a disabled [Button](?path=/docs/navigation-components-button--docs). Unfortunately due to the implementation of button which prioritizes simpler and easier to customize code, the hover is blocked which causes the tooltip to not show up.
+The workaround for this is to wrap your disabled button in a span and put the tooltip on the span instead.
+
+<span className="sb-button-fix" data-tooltip-text="This is a tooltip">
+  <button className="btn" disabled>
+    Disabled Button
+  </button>
+</span>
+
+```html
+<span data-tooltip-text="This is a tooltip">
+  <button class="btn" disabled>Disabled Button</button>
+</span>
+```
+
 ## Variations
 
 ### Default


### PR DESCRIPTION
## Why?

Tooltips on Disabled buttons do not show up. We want to add some documentation for how to work around it.

## What Changed

- [X] Add example in the docs

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

<img width="1043" alt="Screenshot 2024-02-07 at 4 37 54 PM" src="https://github.com/RoleModel/optics/assets/5957102/783f22dd-fe8b-4e54-9990-bfbecb54eff9">
