### PR TITLE
[OP-150] Aligned Header Recipe

### DIFF
--- a/.storybook/documentation.scss
+++ b/.storybook/documentation.scss
@@ -2,6 +2,7 @@
 
 @import './src/recipes/domains-sidebar';
 @import './src/recipes/16six-sidebar';
+@import './src/recipes/aligned-header';
 
 @import 'https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap';
 

--- a/src/recipes/aligned-header.scss
+++ b/src/recipes/aligned-header.scss
@@ -1,0 +1,20 @@
+%aligned-header {
+  // Public API (allowed to be overridden)
+  --_op-line-height: var(--op-line-height-base);
+  --_op-font-size: var(--op-font-4x-large);
+
+  font-size: var(--_op-font-size);
+  font-weight: var(--op-font-weight-semi-bold);
+  line-height: var(--_op-line-height);
+
+  .aligned-header__suffix {
+    display: inline-flex;
+    height: calc(var(--_op-line-height) * var(--_op-font-size));
+    align-items: center;
+    vertical-align: top;
+  }
+}
+
+.aligned-header {
+  @extend %aligned-header;
+}

--- a/src/recipes/aligned-header.scss
+++ b/src/recipes/aligned-header.scss
@@ -7,7 +7,7 @@
   font-weight: var(--op-font-weight-semi-bold);
   line-height: var(--_op-line-height);
 
-  .aligned-header__suffix {
+  .aligned-header__centered-suffix {
     display: inline-flex;
     height: calc(var(--_op-line-height) * var(--_op-font-size));
     align-items: center;

--- a/src/stories/Recipes/AlignedHeader/AlignedHeader.js
+++ b/src/stories/Recipes/AlignedHeader/AlignedHeader.js
@@ -9,7 +9,7 @@ export const createAlignedHeader = ({ example = 'badge' }) => {
   <div class='app__content margin-y-lg'>
     <div class='aligned-header'>
       <span>This is a really long heading that will probably wrap at some point and that will make aligning something at the end of the text rather difficult.</span>
-      <div class='aligned-header__suffix'>
+      <div class='aligned-header__centered-suffix'>
         ${example === 'badge' ? badgeSuffix : iconButtonSuffix}
       </span>
     </div>

--- a/src/stories/Recipes/AlignedHeader/AlignedHeader.js
+++ b/src/stories/Recipes/AlignedHeader/AlignedHeader.js
@@ -1,0 +1,19 @@
+export const createAlignedHeader = ({ example = 'badge' }) => {
+  const badgeSuffix = "<div class='badge'>Aligned Badge</div>"
+  const iconButtonSuffix = `<button class='btn btn--no-border btn--icon btn--pill btn--small'>
+          <span class='material-symbols-outlined'>info</span>
+        </button>`
+
+  return `
+<div class='app-body' style="height: 80rem;"> <!-- This class should be on body. Height is for demo purposed -->
+  <div class='app__content margin-y-lg'>
+    <div class='aligned-header'>
+      <span>This is a really long heading that will probably wrap at some point and that will make aligning something at the end of the text rather difficult.</span>
+      <div class='aligned-header__suffix'>
+        ${example === 'badge' ? badgeSuffix : iconButtonSuffix}
+      </span>
+    </div>
+  </div>
+</div>
+`
+}

--- a/src/stories/Recipes/AlignedHeader/AlignedHeader.mdx
+++ b/src/stories/Recipes/AlignedHeader/AlignedHeader.mdx
@@ -5,7 +5,7 @@ import * as AlignedHeaderStories from './AlignedHeader.stories'
 
 # Aligned Header
 
-There are cases when you want something to align with text that may wrap. Like a badge or edit button at the end of a text header that may wrap.
+There are cases when you want to vertically center something on a line of text that wraps. Like a badge or edit button at the end of a text header.
 Achieving this can be tricky as a simple flex or grid solution would result in the badge or button coming after the wrapped text in another block instead of inline with the wrapped text at the end of it.
 
 Here is a solution that manually calculates the height of the suffix section based on the overall font size and line height. In this case, we need to explicity set those in order to calculate the height of the suffix section.
@@ -29,7 +29,7 @@ This is not a common problem and your particular use-case may need to tweak the 
   font-weight: var(--op-font-weight-semi-bold);
   line-height: var(--_op-line-height);
 
-  .aligned-header__suffix {
+  .aligned-header__centered-suffix {
     display: inline-flex;
     height: calc(var(--_op-line-height) * var(--_op-font-size));
     align-items: center;

--- a/src/stories/Recipes/AlignedHeader/AlignedHeader.mdx
+++ b/src/stories/Recipes/AlignedHeader/AlignedHeader.mdx
@@ -1,0 +1,51 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks'
+import * as AlignedHeaderStories from './AlignedHeader.stories'
+
+<Meta of={AlignedHeaderStories} />
+
+# Aligned Header
+
+There are cases when you want something to align with text that may wrap. Like a badge or edit button at the end of a text header that may wrap.
+Achieving this can be tricky as a simple flex or grid solution would result in the badge or button coming after the wrapped text in another block instead of inline with the wrapped text at the end of it.
+
+Here is a solution that manually calculates the height of the suffix section based on the overall font size and line height. In this case, we need to explicity set those in order to calculate the height of the suffix section.
+This is not a common problem and your particular use-case may need to tweak the implementation. Ultimately, this is not general enough to warrant being a full component in the library, but it is a good example of how to solve this specific problem.
+
+## Playground
+
+<Canvas of={AlignedHeaderStories.Badge} />
+<Controls of={AlignedHeaderStories.Badge} />
+
+## Badge Example
+
+```css
+// Badge Example
+%aligned-header {
+  // Public API (allowed to be overridden)
+  --_op-line-height: var(--op-line-height-base);
+  --_op-font-size: var(--op-font-4x-large);
+
+  font-size: var(--_op-font-size);
+  font-weight: var(--op-font-weight-semi-bold);
+  line-height: var(--_op-line-height);
+
+  .aligned-header__suffix {
+    display: inline-flex;
+    height: calc(var(--_op-line-height) * var(--_op-font-size));
+    align-items: center;
+    vertical-align: top;
+  }
+}
+
+.aligned-header {
+  @extend %aligned-header;
+}
+```
+
+<Canvas of={AlignedHeaderStories.Badge} />
+
+## Icon Button Example
+
+The CSS is the same as the previous example, but the markup is different.
+
+<Canvas of={AlignedHeaderStories.IconButton} />

--- a/src/stories/Recipes/AlignedHeader/AlignedHeader.stories.js
+++ b/src/stories/Recipes/AlignedHeader/AlignedHeader.stories.js
@@ -1,0 +1,29 @@
+import { createAlignedHeader } from './AlignedHeader.js'
+
+export default {
+  title: 'Recipes/Aligned Header',
+  render: ({ ...args }) => {
+    return createAlignedHeader({ ...args })
+  },
+  argTypes: {
+    example: {
+      control: { type: 'select' },
+      options: ['badge', 'icon-button'],
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export const Badge = {
+  args: {
+    example: 'badge',
+  },
+}
+
+export const IconButton = {
+  args: {
+    example: 'icon-button',
+  },
+}


### PR DESCRIPTION
## Why?

This is a problem that came up. The solution isn't a general component level solution, but having it as a recipe can help people if they do encounter it.

## What Changed

- [X] Add docs with example

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

<img width="1151" alt="Screenshot 2024-02-07 at 5 36 39 PM" src="https://github.com/RoleModel/optics/assets/5957102/4ad6de47-3fb0-4f04-b65b-67896926be68">
<img width="1042" alt="Screenshot 2024-02-07 at 5 36 58 PM" src="https://github.com/RoleModel/optics/assets/5957102/7dc07e9e-32d2-467e-9a4f-7b29fa1fa128">
<img width="1011" alt="Screenshot 2024-02-07 at 5 36 47 PM" src="https://github.com/RoleModel/optics/assets/5957102/6f966f23-956a-4cb2-8b28-5a48482a080f">
<img width="1040" alt="Screenshot 2024-02-07 at 5 36 51 PM" src="https://github.com/RoleModel/optics/assets/5957102/cd707261-9ea5-4cbc-a89e-9966e5927fa2">
