### PR TITLE
[OP-25] Compound Selector with ::file-selector-button

### DIFF
--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -159,21 +159,33 @@
     padding-block: 0;
 
     &::file-selector-button {
-      @extend %btn-global;
+      --__op-btn-base-height: var(--op-input-height-small);
+      --__op-btn-height: var(--__op-btn-base-height);
 
-      --__op-btn-height: var(--_op-btn-height-small);
-      --__op-btn-font-size: var(--_op-btn-font-small);
-      --__op-btn-padding: var(--_op-btn-padding-small);
-
+      display: inline-flex;
+      min-height: var(--__op-btn-height);
+      align-items: center;
+      justify-content: center;
+      padding: 0 var(--op-space-x-small);
       border: none;
+      border-radius: var(--op-radius-medium);
+      appearance: none;
       background-color: var(--op-color-neutral-plus-eight);
       box-shadow: inset var(--op-border-all) var(--op-color-neutral-plus-four);
       color: var(--op-color-neutral-on-plus-eight);
+      cursor: pointer;
+      font-size: var(--op-font-x-small);
+      font-weight: var(--op-font-weight-normal);
+      gap: var(--op-space-x-small);
       margin-block: calc((var(--__op-form-control-height) / 2) - (var(--__op-btn-height) / 2));
+      text-align: center;
+      text-decoration: none;
+      transition: var(--op-transition-input);
+      white-space: nowrap;
     }
 
     &.form-control--small::file-selector-button {
-      --__op-btn-height: calc(var(--_op-btn-height-small) - var(--op-space-x-small));
+      --__op-btn-height: calc(var(--__op-btn-base-height) - var(--op-space-x-small));
     }
   }
 


### PR DESCRIPTION
## Why?

There is an issue with compound selectors that have a child under `::file-selector-button` in it. It breaks the whole selector

Due to how the file selector button is styled, if you put a child selector in the button global style, it will break it.

E.G. Always styling icons within buttons with a certain color

```css
%btn-global {
  .material-symbols-outlined {
    color: red;
  }
}

// Output that is broken
.form-control[type=file]::file-selector-button .material-symbols-outlined,
.btn .material-symbols-outlined {
  color: red;
}
```

Technically this is a breaking change though I suspect not many projects are styling the file selector button so it may not be an issue.

## What Changed

- [X] Reimplement the file selector button styles to not extend the button

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

<img width="482" alt="Screenshot 2024-02-14 at 3 36 34 PM" src="https://github.com/RoleModel/optics/assets/5957102/c4af3f27-bcef-4680-ae67-99cd7d246a8e">
