### PR TITLE
[OP-152] Rename btn-delete to btn-destructive

### DIFF
--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -219,6 +219,7 @@
   }
 }
 
+.btn-destructive,
 .btn-delete {
   @extend %btn-global;
 

--- a/src/components/button_group.scss
+++ b/src/components/button_group.scss
@@ -8,10 +8,12 @@
 
   .btn,
   .btn-primary,
+  .btn-destructive,
   .btn-delete,
   .btn-warning {
     + .btn,
     + .btn-primary,
+    + .btn-destructive,
     + .btn-delete,
     + .btn-warning {
       margin-left: -1px;

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -42,11 +42,12 @@ Button can be used as a standalone component, however, it does have a few depend
 
 <Canvas of={ButtonStories.Primary} />
 
-### Delete
+### Destructive
 
-`.btn-delete` Provides a filled button using the red danger color. This should be used as a destructive action such as delete.
+`.btn-destructive` Provides a filled button using the red danger color. This should be used as a destructive action such as delete.
+Note: `.btn-delete` also works for backwards compatibility, but `.btn-destructive` is the preferred class name.
 
-<Canvas of={ButtonStories.Delete} />
+<Canvas of={ButtonStories.Destructive} />
 
 ### Active
 
@@ -56,9 +57,9 @@ Button can be used as a standalone component, however, it does have a few depend
 
 ### No Border
 
-`.btn--no-border` This is a modifier which can be used with all button classes except delete. It provides a button with no border, but the same sizing and adapts it's color to all the btn variations.
+`.btn--no-border` This is a modifier which can be used with all button classes except destructive. It provides a button with no border, but the same sizing and adapts it's color to all the btn variations.
 
-Note: `.btn-delete` and `.btn-warning` do not support the `.btn--no-border` modifier. Borderless warning or delete buttons is not considered a good pattern and can easily lead to confusion so it has been disabled.
+Note: `.btn-destructive` and `.btn-warning` do not support the `.btn--no-border` modifier. Borderless warning or destructive buttons is not considered a good pattern and can easily lead to confusion so it has been disabled.
 
 <Canvas of={ButtonStories.NoBorder} />
 

--- a/src/stories/Components/Button/Button.stories.js
+++ b/src/stories/Components/Button/Button.stories.js
@@ -9,7 +9,7 @@ export default {
     label: { control: 'text' },
     priority: {
       control: { type: 'select' },
-      options: ['default', 'primary', 'delete', 'warning'],
+      options: ['default', 'primary', 'destructive', 'warning'],
     },
     noBorder: { control: 'boolean' },
     disabled: { control: 'boolean' },
@@ -47,10 +47,10 @@ export const Primary = {
   },
 }
 
-export const Delete = {
+export const Destructive = {
   args: {
     label: 'Delete',
-    priority: 'delete',
+    priority: 'destructive',
   },
 }
 

--- a/src/stories/Components/ButtonGroup/ButtonGroup.mdx
+++ b/src/stories/Components/ButtonGroup/ButtonGroup.mdx
@@ -43,9 +43,9 @@ Button Group can be used as a standalone component, however, it does have a few 
 
 <Canvas of={ButtonGroupStories.Primary} />
 
-### Delete
+### Destructive
 
-<Canvas of={ButtonGroupStories.Delete} />
+<Canvas of={ButtonGroupStories.Destructive} />
 
 ### Warning
 

--- a/src/stories/Components/ButtonGroup/ButtonGroup.stories.js
+++ b/src/stories/Components/ButtonGroup/ButtonGroup.stories.js
@@ -12,7 +12,7 @@ export default {
   argTypes: {
     priority: {
       control: { type: 'select' },
-      options: ['default', 'primary', 'delete', 'warning'],
+      options: ['default', 'primary', 'destructive', 'warning'],
     },
     noBorder: { control: 'boolean' },
     active: { control: 'boolean' },
@@ -41,9 +41,9 @@ export const Primary = {
   },
 }
 
-export const Delete = {
+export const Destructive = {
   args: {
-    priority: 'delete',
+    priority: 'destructive',
   },
 }
 
@@ -55,7 +55,7 @@ export const Warning = {
 
 export const Active = {
   args: {
-    priority: 'delete',
+    priority: 'destructive',
     active: true,
   },
 }

--- a/src/stories/Components/ConfirmDialog/ConfirmDialog.js
+++ b/src/stories/Components/ConfirmDialog/ConfirmDialog.js
@@ -14,7 +14,7 @@ export const createConfirmDialog = ({ title, message, inlineDemo = false }) => {
     </div>
     <div class='confirm-dialog__footer'>
       <button class="btn">Cancel</button>
-      <button class='btn-delete'>Yes, I'm Sure</button>
+      <button class='btn-destructive'>Yes, I'm Sure</button>
     </div>
   </div>
 `


### PR DESCRIPTION
## Why?

From a semantic perspective, delete doesn't match other buttons. The original reason for the naming was to convey more intention when using it. `destructive` is just as semantic, but allows for broader use cases like closing an account (that may be recoverable)

## What Changed

- [X] Add `btn-destructive` class
- [X] Update documentation terminology
- [X] Retail `btn-delete` so as to not cause breaking changes

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

<img width="1060" alt="Screenshot 2024-02-16 at 2 37 36 PM" src="https://github.com/RoleModel/optics/assets/5957102/7e7801c6-29d9-4a00-a3d4-dcdfaf2ed00b">
