### PR TITLE
[OP-158] Fix tab link in docs

### DIFF
--- a/src/stories/Components/Tab/Tab.js
+++ b/src/stories/Components/Tab/Tab.js
@@ -4,7 +4,7 @@ export const createTab = ({ size = 'large', activeTab = 'USA', disabledTab = 'Ca
 
   const createTabItem = (item) => {
     const link = document.createElement('a')
-    link.href = '/?path=/docs/components-tab--docs'
+    link.href = '/?path=/docs/navigation-components-tab--docs'
 
     link.className = [
       'tab',


### PR DESCRIPTION
## Why?

This bug was caused by the recent reorganization of documentation revealing a hard-coded link in the tab example

## What Changed

- [X] Fix link

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~
