### PR TITLE
[OP#161] Use correct cursor for color input

### DIFF
--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -139,6 +139,7 @@
 
   &[type='color'] {
     padding: var(--op-space-2x-small);
+    cursor: pointer;
 
     &::-webkit-color-swatch-wrapper {
       padding: 0;


### PR DESCRIPTION
## Why?

The color input showed the text cursor instead of pointer on hover. It should be the pointer since it opens the color picker menu.

## What Changed

- [X] Use correct pointer

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

### Before

![IMG_3084](https://github.com/user-attachments/assets/9291315d-3929-4534-b44e-c1f553feaad7)

### After

![IMG_3085](https://github.com/user-attachments/assets/c1178f9f-22d6-4a04-b288-3dd4940523d5)
