### PR TITLE
[OP#162] Use the correct z index for the sidebar

### DIFF
--- a/src/addons/panel.scss
+++ b/src/addons/panel.scss
@@ -2,7 +2,7 @@
   --op-panel-width: 40%;
 
   position: absolute;
-  z-index: var(--op-z-index-drawer);
+  z-index: var(--op-z-index-sidebar);
   right: calc(-1 * var(--op-panel-width)); // this pushes the panel off the sceen to the right
   width: var(--op-panel-width);
   height: 100vh;

--- a/src/components/sidebar.scss
+++ b/src/components/sidebar.scss
@@ -69,6 +69,7 @@
   --__op-sidebar-width: var(--_op-sidebar-drawer-width);
   --__op-sidebar-brand-width: var(--_op-sidebar-drawer-brand-width);
 
+  z-index: var(--op-z-index-drawer);
   display: flex;
   width: var(--__op-sidebar-width);
   min-width: var(--__op-sidebar-width);

--- a/src/components/sidebar.scss
+++ b/src/components/sidebar.scss
@@ -69,7 +69,7 @@
   --__op-sidebar-width: var(--_op-sidebar-drawer-width);
   --__op-sidebar-brand-width: var(--_op-sidebar-drawer-brand-width);
 
-  z-index: var(--op-z-index-drawer);
+  z-index: var(--op-z-index-sidebar);
   display: flex;
   width: var(--__op-sidebar-width);
   min-width: var(--__op-sidebar-width);

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -297,7 +297,7 @@ $breakpoint-x-large: 1440px; // medium laptop
   */
   --op-z-index-header: 500;
   --op-z-index-footer: 500;
-  --op-z-index-drawer: 700;
+  --op-z-index-sidebar: 700;
   --op-z-index-dialog: 800;
   --op-z-index-dialog-backdrop: 801;
   --op-z-index-dialog-content: 802;


### PR DESCRIPTION
## Why?

The sidebar was not using a z index which caused the navbar (if used in combination) was covering up the sidebar border.

## What Changed

- [X] Use the drawer z index on sidebar

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

### Before

<img width="503" alt="Screenshot 2024-07-30 at 4 58 41 PM" src="https://github.com/user-attachments/assets/862a9add-b4fe-41f1-b440-e8ff19d58d3f">

### After

<img width="612" alt="Screenshot 2024-07-30 at 4 58 33 PM" src="https://github.com/user-attachments/assets/341dc4ee-f0c2-48cc-a941-76db2ff8307c">
