### PR TITLE
Fix href Link on Avatar Component

### DIFF
--- a/src/stories/Components/Avatar/Avatar.js
+++ b/src/stories/Components/Avatar/Avatar.js
@@ -6,7 +6,7 @@ export const createAvatar = ({
 }) => {
   const element = document.createElement(useLink ? 'a' : 'div')
 
-  element.href = '/?path=/docs/components-avatar--docs'
+  element.href = '/?path=/docs/content-components-avatar--docs'
   element.className = `avatar avatar--${size}`
 
   const image = document.createElement('img')


### PR DESCRIPTION
## Why?

The current href link on the Avatar component is `components-avatar--docs` and the actual path is `content-components-avatar--docs`. The breaking difference being that `content` is missing.

## What Changed

What changed in this PR?

- [X] Corrected the href link

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~