### PR TITLE
Improve icon font initial page load state

### DIFF
--- a/src/components/icon.scss
+++ b/src/components/icon.scss
@@ -3,7 +3,7 @@
 // from Googles CDN like we do for our other fonts
 // https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
 
-@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200';
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block';
 
 .material-symbols-outlined,
 .material-symbols {


### PR DESCRIPTION
## Why?

According to recommendations here https://developers.google.com/fonts/docs/material_symbols#optimize_the_icon_font we should be using the display block option to prevent the icon text from rendering during load. See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for details on what this setting actually does.

## What Changed

- [X] Add `&display=block` to icon font import

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~
