### PR TITLE
CCC-44 Breakpoint Variables

### DIFF
--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -202,7 +202,8 @@
     }
   }
 
-  @media (width <= $breakpoint-small) {
+  // --op-breakpoint-small
+  @media (width <= 768px) {
     flex-direction: column;
 
     .btn {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "packageManager": "yarn@4.2.2",
   "description": "Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/scss/optics.scss",

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -91,7 +91,8 @@
   }
 
   // https://uxmovement.com/mobile/optimal-size-and-spacing-for-mobile-buttons/
-  @media (max-width: $breakpoint-small) {
+  // --op-breakpoint-small
+  @media (width <= 768px) {
     --__op-btn-height: var(--_op-btn-height-large);
     --__op-btn-font-size: var(--_op-btn-font-large);
 

--- a/src/components/sidebar.scss
+++ b/src/components/sidebar.scss
@@ -132,12 +132,14 @@
     @include sidebar-drawer-global;
   }
 
+  // --op-breakpoint-medium
   &.sidebar--drawer.sidebar--responsive {
-    @media (width > $breakpoint-medium) {
+    @media (width > 1024px) {
       @include sidebar-drawer-global;
     }
 
-    @media (width <= $breakpoint-medium) {
+    // --op-breakpoint-medium
+    @media (width <= 1024px) {
       @include sidebar-rail-global;
     }
   }
@@ -147,12 +149,14 @@
     @include sidebar-compact-global;
   }
 
+  // --op-breakpoint-medium
   &.sidebar--compact.sidebar--responsive {
-    @media (width > $breakpoint-medium) {
+    @media (width > 1024px) {
       @include sidebar-compact-global;
     }
 
-    @media (width <= $breakpoint-medium) {
+    // --op-breakpoint-medium
+    @media (width <= 1024px) {
       @include sidebar-rail-global;
     }
   }

--- a/src/components/sidebar.scss
+++ b/src/components/sidebar.scss
@@ -132,8 +132,8 @@
     @include sidebar-drawer-global;
   }
 
-  // --op-breakpoint-medium
   &.sidebar--drawer.sidebar--responsive {
+    // --op-breakpoint-medium
     @media (width > 1024px) {
       @include sidebar-drawer-global;
     }
@@ -149,8 +149,8 @@
     @include sidebar-compact-global;
   }
 
-  // --op-breakpoint-medium
   &.sidebar--compact.sidebar--responsive {
+    // --op-breakpoint-medium
     @media (width > 1024px) {
       @include sidebar-compact-global;
     }

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -102,11 +102,18 @@
   --op-breakpoint-x-large: 1440px; // medium laptop
 }
 
-$breakpoint-x-small: 512px; // vertical phone
-$breakpoint-small: 768px; // vertical ipad
-$breakpoint-medium: 1024px; // landscape ipad
-$breakpoint-large: 1280px; // small laptop
-$breakpoint-x-large: 1440px; // medium laptop
+/*
+  Breakpoints
+  Because CSS does not support any form of custom variables in @media() or @container() queries,
+  and because env() variables do not support custom values, we have to use raw values. We're
+  documenting the variables here to assist with updating the raw values as needed.
+
+  --op-breakpoint-x-small: 512px;
+  --op-breakpoint-small: 768px;
+  --op-breakpoint-medium: 1024px;
+  --op-breakpoint-large: 1280px;
+  --op-breakpoint-x-large: 1440px;
+*/
 
 @mixin border-radius {
   /**

--- a/src/core/tokens/base_tokens.scss
+++ b/src/core/tokens/base_tokens.scss
@@ -85,11 +85,20 @@
   --op-opacity-full: 1;
 }
 
-// Breakpoints are duplicated here for use as variables with calculations and for use in @media queries.
-// We use SCSS variables outside the root since support for custom properties / css variables
-// is not yet available
-// https://drafts.csswg.org/css-env-1/
-// https://bholmes.dev/blog/alternative-to-css-variable-media-queries/
+/*
+  Breakpoints
+  CSS does not support using variables within @media or @container queries. Environment variables are drafted but likely to not be implemented soon.
+  https://drafts.csswg.org/css-env-1/
+  https://bholmes.dev/blog/alternative-to-css-variable-media-queries/
+
+  Here is a list of breakpoints used throughout Optics
+
+  --op-breakpoint-x-small: 512px;
+  --op-breakpoint-small: 768px;
+  --op-breakpoint-medium: 1024px;
+  --op-breakpoint-large: 1280px;
+  --op-breakpoint-x-large: 1440px;
+*/
 @mixin breakpoints {
   /**
   * @tokens Breakpoints
@@ -101,19 +110,6 @@
   --op-breakpoint-large: 1280px; // small laptop
   --op-breakpoint-x-large: 1440px; // medium laptop
 }
-
-/*
-  Breakpoints
-  Because CSS does not support any form of custom variables in @media() or @container() queries,
-  and because env() variables do not support custom values, we have to use raw values. We're
-  documenting the variables here to assist with updating the raw values as needed.
-
-  --op-breakpoint-x-small: 512px;
-  --op-breakpoint-small: 768px;
-  --op-breakpoint-medium: 1024px;
-  --op-breakpoint-large: 1280px;
-  --op-breakpoint-x-large: 1440px;
-*/
 
 @mixin border-radius {
   /**

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -101,7 +101,7 @@ Note: `.btn-destructive` and `.btn-warning` do not support the `.btn--no-border`
 
 ## Mobile Buttons
 
-All button classes, regardless of the currently applied size modifier, will automatically adjust to the large button size on mobile screens ($breakpoint-small ~ 768px).
+All button classes, regardless of the currently applied size modifier, will automatically adjust to the large button size on mobile screens (--op-breakpoint-small ~ 768px).
 This is to ensure a large enough tap area on smaller devices and screens.
 
 See https://uxmovement.com/mobile/optimal-size-and-spacing-for-mobile-buttons/

--- a/src/stories/Tokens/Breakpoint.mdx
+++ b/src/stories/Tokens/Breakpoint.mdx
@@ -14,18 +14,19 @@ import { DesignTokenDocBlock } from 'storybook-design-token'
 
 Breakpoint tokens are used to define common device sizes for use within media queries or max widths.
 
-They are implemented in two ways. First as CSS custom properties (css variables) and second as SCSS variables.
+They are implemented in two ways. First as CSS custom properties (css variables) and second as guided pixel assignments.
 
 The CSS variables can be used like any of the other tokens for things requiring calculations or max widths.
 
-The SCSS variables can be used for media queries.
+The The guided pixel assignments can be used for media queries.
 
 Custom properties (css variables) currently cannot be used in a media query since they get defined in an element scope (`:root` in our case).
 Media queries exist at the document level and therefore cannot access custom properties.
 
 [CSS ENV Variables](https://drafts.csswg.org/css-env-1/) aims at addressing this by allowing variables at the global document level.
 
-[SCSS Workaround](https://bholmes.dev/blog/alternative-to-css-variable-media-queries/) is the pattern we follow to achieve this.
+The pattern we use for media queries is to define the variables in the :root as a comment block. When trying to apply the variable in a media
+query, we have to use the pixel values themselves with a comment above referring to the variable assigned to that value.
 
 ## Usage
 
@@ -36,7 +37,19 @@ These tokens can be applied in a media query to create responsive behavior.
   max-width: var(--op-breakpoint-small);
 }
 
-@media (width > $breakpoint-medium) {
+:root {
+  /*
+  Breakpoints
+  These breakpoint values will be used as a guide for media queries.
+  Annotate the uses with a comment above referring to the variable being referenced.
+
+  --op-breakpoint-medium: 1024px;
+  ...
+  */
+}
+
+// --op-breakpoint-medium
+@media (width > 1024px) {
   background-color: var(--op-color-primary-base);
   color: var(--op-color-primary-on-base);
 }

--- a/src/stories/Tokens/Breakpoint.mdx
+++ b/src/stories/Tokens/Breakpoint.mdx
@@ -18,19 +18,19 @@ They are implemented in two ways. First as CSS custom properties (css variables)
 
 The CSS variables can be used like any of the other tokens for things requiring calculations or max widths.
 
-The The guided pixel assignments can be used for media queries.
+The guided pixel assignments can be used for media queries.
 
 Custom properties (css variables) currently cannot be used in a media query since they get defined in an element scope (`:root` in our case).
 Media queries exist at the document level and therefore cannot access custom properties.
 
 [CSS ENV Variables](https://drafts.csswg.org/css-env-1/) aims at addressing this by allowing variables at the global document level.
 
-The pattern we use for media queries is to define the variables in the :root as a comment block. When trying to apply the variable in a media
+The pattern we use for media queries is to define the variables in the `:root` as a comment block. When trying to apply the variable in a media
 query, we have to use the pixel values themselves with a comment above referring to the variable assigned to that value.
 
 ## Usage
 
-These tokens can be applied in a media query to create responsive behavior.
+These token values can be applied in a media query to create responsive behavior.
 
 ```css
 .small-area {

--- a/src/stories/Tokens/Breakpoint.mdx
+++ b/src/stories/Tokens/Breakpoint.mdx
@@ -25,8 +25,7 @@ Media queries exist at the document level and therefore cannot access custom pro
 
 [CSS ENV Variables](https://drafts.csswg.org/css-env-1/) aims at addressing this by allowing variables at the global document level.
 
-The pattern we use for media queries is to define the variables in the `:root` as a comment block. When trying to apply the variable in a media
-query, we have to use the pixel values themselves with a comment above referring to the variable assigned to that value.
+For common breakpoints, define the variables in the `:root` as a comment block. When using them, use the pixel value, but include a comment above with the named breakpoint. This makes it searchable and provide a bit of intention to what the value means.
 
 ## Usage
 

--- a/src/stories/Utilities/Container/Container.mdx
+++ b/src/stories/Utilities/Container/Container.mdx
@@ -23,19 +23,19 @@ You may need to zoom the demos out depending on your screen size to see the full
 
 ## Default
 
-`.container` Create a container area set to be the size of `$breakpoint-medium` with a padding of `--op-space-large`
+`.container` Create a container area set to be the size of `--op-breakpoint-medium` with a padding of `--op-space-large`
 
 <Canvas of={ContainerStories.Default} />
 
 ## Small Size
 
-`.container--sm` Change the container size to `$breakpoint-small`
+`.container--sm` Change the container size to `--op-breakpoint-small`
 
 <Canvas of={ContainerStories.SizeSmall} />
 
 ## Extra Small Size
 
-`.container--xs` Change the container size to `$breakpoint-x-small`
+`.container--xs` Change the container size to `--op-breakpoint-x-small`
 
 <Canvas of={ContainerStories.SizeExtraSmall} />
 


### PR DESCRIPTION
## Why?

In an effort to reduce dependencies on SCSS features, we want to remove the `$breakpoint-...` SCSS variables. Media queries cannot use CSS variables and the spec for environment variables doesn't seem like it is moving anytime soon. https://drafts.csswg.org/css-env-1/

## What Changed

- [x] Replaced the $breakpoint tokens with a comment guide
- [x] Replaced the use of $breakpoint tokens with their pixel definitions and a comment above relating to the token name
- [x] Updated the mdx guides with when they are used and how to use them

## Sanity Check

- [x] Have you updated any usage of changed tokens?
- [x] Have you updated the docs with any component changes?
- ~[ ] Have you updated the dependency graph with any component changes?~
- [x] Have you run linters?
- [x] Have you run prettier?
- [x] Have you tried building the css?
- [x] Have you tried building storybook?
- [x] Do you need to update the package version?