### PR TITLE
OP-189 Refactor Table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "packageManager": "yarn@4.2.2",
   "description": "Optics is an scss package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/scss/optics.scss",

--- a/src/components/table.css
+++ b/src/components/table.css
@@ -25,7 +25,6 @@
     box-shadow: inset var(--op-border-top) var(--op-color-border);
     color: var(--op-color-neutral-on-plus-eight);
 
-    /* This Currently does not work in Firefox since it does not support :has yet, but fails gracefully. */
     &:has(th input[type='checkbox']:checked) {
       background-color: var(--op-color-primary-plus-seven);
       color: var(--op-color-primary-on-plus-seven);

--- a/src/components/table.css
+++ b/src/components/table.css
@@ -1,12 +1,14 @@
-%table-global {
-  // Public API
-  // Cells (for height, the appropriate variable is used when using the density modifiers)
-  --_op-table-cell-height-default: calc(11 * var(--op-size-unit)); // 44px
-  --_op-table-cell-height-comfortable: calc(16 * var(--op-size-unit)); // 64px
-  --_op-table-cell-height-compact: calc(8 * var(--op-size-unit)); // 32px
+.table {
+  /* Public API */
 
-  // Private API
-  // These allow for overriding specific padding versions easier.
+  /* Cells (for height, the appropriate variable is used when using the density modifiers) */
+  --_op-table-cell-height-default: calc(11 * var(--op-size-unit)); /* 44px */
+  --_op-table-cell-height-comfortable: calc(16 * var(--op-size-unit)); /* 64px */
+  --_op-table-cell-height-compact: calc(8 * var(--op-size-unit)); /* 32px */
+
+  /* Private API */
+
+  /* These allow for overriding specific padding versions easier. */
   --__op-table-cell-height: var(--_op-table-cell-height-default);
 
   width: 100%;
@@ -16,12 +18,14 @@
   contain: paint;
   table-layout: auto;
 
+  /* Elements */
+
   thead {
     background-color: var(--op-color-neutral-plus-eight);
     box-shadow: inset var(--op-border-top) var(--op-color-border);
     color: var(--op-color-neutral-on-plus-eight);
 
-    // This Currently does not work in Firefox since it does not support :has yet, but fails gracefully.
+    /* This Currently does not work in Firefox since it does not support :has yet, but fails gracefully. */
     &:has(th input[type='checkbox']:checked) {
       background-color: var(--op-color-primary-plus-seven);
       color: var(--op-color-primary-on-plus-seven);
@@ -42,19 +46,42 @@
   th,
   td {
     height: var(--__op-table-cell-height);
-    padding: var(--op-space-2x-small) var(--op-space-small);
     font-size: var(--op-font-small);
-  }
-
-  tr:not(:last-child) {
-    box-shadow: inset var(--op-border-top) var(--op-color-border);
+    padding-block: var(--op-space-2x-small);
+    padding-inline: var(--op-space-small);
   }
 
   tfoot tr {
     box-shadow: var(--op-border-top) var(--op-color-border);
   }
 
-  // Layout Modifiers
+  tr:not(:last-child) {
+    box-shadow: inset var(--op-border-top) var(--op-color-border);
+  }
+
+  /* Modifiers */
+
+  /* stylelint-disable no-descending-specificity */
+  &.table--primary {
+    thead {
+      background-color: var(--op-color-primary-plus-seven);
+      color: var(--op-color-primary-on-plus-seven);
+    }
+  }
+
+  &.table--danger {
+    thead {
+      background-color: var(--op-color-alerts-danger-plus-seven);
+      color: var(--op-color-alerts-danger-on-plus-seven);
+    }
+  }
+  /* stylelint-enable no-descending-specificity */
+
+  &.table--container {
+    overflow-y: auto;
+  }
+
+  /* Layout Modifiers */
   &.table--auto-layout {
     table-layout: auto;
   }
@@ -63,7 +90,7 @@
     table-layout: fixed;
   }
 
-  // Table Density Modifiers
+  /* Table Density Modifiers */
   &.table--default-density {
     --__op-table-cell-height: var(--_op-table-cell-height-default);
   }
@@ -76,7 +103,7 @@
     --__op-table-cell-height: var(--_op-table-cell-height-compact);
   }
 
-  // Striped Modifiers
+  /* Striped Modifiers */
   &.table--even-striped {
     tbody tr:nth-child(even) {
       background-color: var(--op-color-neutral-plus-seven);
@@ -91,47 +118,17 @@
     }
   }
 
-  // Sticky Header Row Modifier
+  /* Sticky Header Row Modifier */
+  /* stylelint-disable no-descending-specificity */
   &.table--sticky-header thead {
     position: sticky;
-    top: 0;
+    inset-block-start: 0;
   }
+  /* stylelint-enable no-descending-specificity */
 
-  // Sticky Footer Row Modifier
+  /* Sticky Footer Row Modifier */
   &.table--sticky-footer tfoot {
     position: sticky;
-    bottom: 0;
+    inset-block-end: 0;
   }
-}
-
-// Default Table
-.table {
-  @extend %table-global;
-}
-
-// Primary Table
-.table-primary {
-  @extend %table-global;
-
-  thead {
-    background-color: var(--op-color-primary-plus-seven);
-    color: var(--op-color-primary-on-plus-seven);
-  }
-}
-
-// Danger Table
-.table-danger {
-  @extend %table-global;
-
-  thead {
-    background-color: var(--op-color-alerts-danger-plus-seven);
-    color: var(--op-color-alerts-danger-on-plus-seven);
-  }
-}
-
-// Sticky Header / Footer Table Container
-.table-container {
-  @extend %table-global;
-
-  overflow-y: auto;
 }

--- a/src/stories/Components/Table/Table.js
+++ b/src/stories/Components/Table/Table.js
@@ -11,7 +11,7 @@ export const createTable = ({
   paginationInFooter = false,
 }) => {
   const tableContainer = document.createElement('div')
-  tableContainer.className = 'table-container'
+  tableContainer.className = 'table table--container'
 
   const table = document.createElement('table')
 
@@ -24,7 +24,8 @@ export const createTable = ({
   }
 
   table.className = [
-    style === 'default' ? 'table' : `table-${style}`,
+    'table',
+    style !== 'default' ? `table--${style}` : '',
     `table--${layout}-layout`,
     `table--${density}-density`,
     striped === 'off' ? '' : `table--${striped}-striped`,

--- a/src/stories/Components/Table/Table.mdx
+++ b/src/stories/Components/Table/Table.mdx
@@ -43,25 +43,25 @@ Table can be used as a standalone component, however, it does have a few depende
 
 ### Primary
 
-`.table-primary` Provides a Primary table. This uses the primary color in the header.
+`.table.table--primary` Provides a Primary table. This uses the primary color in the header.
 
 <Canvas of={TableStories.Primary} />
 
 ### Danger
 
-`.table-danger` Provides a Danger table. This uses the danger alert color in the header.
+`.table.table--danger` Provides a Danger table. This uses the danger alert color in the header.
 
 <Canvas of={TableStories.Danger} />
 
 ### Layout
 
-`.table--auto-layout`, `.table--fixed-layout` (with auto being the default) modify the table layout. Auto will adjust according to the contents, fixed will evenly divide based on the amount of columns.
+`.table.table--auto-layout`, `.table.table--fixed-layout` (with auto being the default) modify the table layout. Auto will adjust according to the contents, fixed will evenly divide based on the amount of columns.
 
 <Canvas of={TableStories.FixedLayout} />
 
 ### Density
 
-`.table--default-density`, `.table--comfortable-density`, `table--compact-density` (with default being the default) modify the table cell padding to expand or contract how much space they use.
+`.table.table--default-density`, `.table.table--comfortable-density`, `.table.table--compact-density` (with default being the default) modify the table cell padding to expand or contract how much space they use.
 
 <Canvas of={TableStories.ComfortableDensity} />
 
@@ -69,7 +69,7 @@ Table can be used as a standalone component, however, it does have a few depende
 
 ### Striping
 
-`.table--even-striped`, `.table--odd-striped` color every other (odd or even) row with a light color on the neutral scale.
+`.table.table--even-striped`, `.table.table--odd-striped` color every other (odd or even) row with a light color on the neutral scale.
 
 <Canvas of={TableStories.StripedEven} />
 
@@ -77,7 +77,7 @@ Table can be used as a standalone component, however, it does have a few depende
 
 ### Sticky Header/Footer
 
-`.table--sticky-header`, `.table--sticky-footer` will make either the table header or table footer sticky; the default is top/bottom of the viewport.
+`.table.table--sticky-header`, `.table.table--sticky-footer` will make either the table header or table footer sticky; the default is top/bottom of the viewport.
 
 These are best used in conjunction with a wrapping container fixed table height, though they will work outside of that being sticky to the browser window. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div to achieve correct overflow behavior. You will also need to set a fixed height. This will allow sticky header/footer with scrollable body rows.
 
@@ -128,12 +128,12 @@ Here are the variables used:
   }}
 ></div>
 
-The table classes are built on a [SASS placeholder selector](https://sass-lang.com/documentation/style-rules/placeholder-selectors)
+The table classes are structured using the [BEM methodology](https://getbem.com/naming).
 
-This allows multiple table classes to share the same behavior. You can modify all tables behavior by overriding the `%table-global` placeholder selector and setting any proprerties:
+This allows us to define core styles on a main [block](https://getbem.com/naming/#block) class, and use [modifiers](https://getbem.com/naming/#modifier) to encapsulate variant styles. You can modify all table behavior by overriding the `.table` selector and setting any properties:
 
 ```scss
-%table-global {
+.table {
   font-size: var(--op-font-2x-large);
 }
 ```
@@ -141,7 +141,7 @@ This allows multiple table classes to share the same behavior. You can modify al
 If you want to override how the density modifier behaves, you can use API described above to change which padding each density uses.
 
 ```css
-%table-global {
+.table {
   --_op-table-cell-padding-default: var(--op-space-x-small) var(--op-space-2x-small);
   --_op-table-cell-padding-comfortable: var(--op-space-large) var(--op-space-medium);
   --_op-table-cell-padding-compact: var(--op-space-2x-small) var(--op-space-3x-small);
@@ -152,7 +152,7 @@ If you need to override the color of a particular table style, you can open the 
 
 ```css
 // This will only affect the primary table, but not default or danger
-.table-primary {
+.table--primary {
   thead {
     background-color: purple;
     color: white;
@@ -171,12 +171,10 @@ If you need to override the color of a particular table style, you can open the 
   }}
 ></div>
 
-Your application may need a custom table. To add one, just follow this template:
+Your application may need a variation. To add one, just follow this template. Note the double hyphen, indicating that this is a [modifier](https://getbem.com/naming/#modifier):
 
 ```css
-.table-{name} {
-  @extend %table-global;
-
+.table--{name} {
   thead {
     background-color:
     color:
@@ -185,9 +183,7 @@ Your application may need a custom table. To add one, just follow this template:
 ```
 
 ```css
-.table-purple {
-  @extend %table-global;
-
+.table--purple {
   thead {
     background-color: purple;
     color: white;


### PR DESCRIPTION
## Why?

With the move toward plain css, the Table styling needs to be converted to CSS with a strict adherence to the BEM structure.

## What Changed

What changed in this PR?

- [x] Convert `table.scss` to `table.css` using BEM
- [x] Update the table builder to use the new modifier system
- [x] Update the docs to reflect this change

## Sanity Check

- ~[ ] Have you updated any usage of changed tokens?~
- [x] Have you updated the docs with any component changes?
- ~[ ] Have you updated the dependency graph with any component changes?~
- [x] Have you run linters?
- [x] Have you run prettier?
- [x] Have you tried building the css?
- [x] Have you tried building storybook?
- [x] Do you need to update the package version?