### PR TITLE
[OP-198] Accordion Add Animation

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -86,6 +86,15 @@
   }
 }
 
+.transition-demo--accordion_content {
+  interpolate-size: allow-keywords;
+  transition: var(--op-transition-accordion-content);
+
+  &:hover {
+    height: 15rem;
+  }
+}
+
 .transition-demo--input {
   transition: var(--op-transition-input);
 }

--- a/src/components/accordion.css
+++ b/src/components/accordion.css
@@ -2,6 +2,11 @@
   /* Public API (customizable component options) */
   --_op-accordion-summary-min-height: calc(8 * var(--op-size-unit)); /* 32px */
 
+  overflow: hidden;
+  interpolate-size: allow-keywords;
+
+  /* Elements */
+
   summary {
     display: grid;
     min-height: var(--_op-accordion-summary-min-height);
@@ -32,9 +37,30 @@
     }
   }
 
+  &::details-content {
+    height: 0;
+    transition: var(--op-transition-accordion-content);
+  }
+
   &[open] {
     summary .accordion__marker {
       rotate: 0.25turn;
+    }
+
+    &::details-content {
+      height: auto;
+    }
+  }
+
+  /* Modifiers */
+
+  &.accordion--disable-animation {
+    summary .accordion__marker {
+      transition: none;
+    }
+
+    &::details-content {
+      transition: none;
     }
   }
 }

--- a/src/core/tokens/base_tokens.css
+++ b/src/core/tokens/base_tokens.css
@@ -216,6 +216,7 @@ Noto Sans supports:
   * @tokens Transition
   */
   --op-transition-accordion: rotate 120ms ease-in;
+  --op-transition-accordion-content: height 300ms ease, content-visibility 300ms ease allow-discrete;
   --op-transition-input: all 120ms ease-in;
   --op-transition-sidebar: all 200ms ease-in-out;
   --op-transition-modal: all 300ms ease-in;

--- a/src/stories/Components/Accordion/Accordion.js
+++ b/src/stories/Components/Accordion/Accordion.js
@@ -5,10 +5,15 @@ export const createAccordion = ({
   marker = 'arrow_right',
   additionalHeaderContent = '',
   flipHeaderAndMarker = false,
+  disableAnimation = false,
   content = 'Something small enough to escape casual notice.',
 }) => {
   const element = document.createElement('details')
   element.className = 'accordion'
+
+  if (disableAnimation) {
+    element.className += ' accordion--disable-animation'
+  }
 
   const summary = document.createElement('summary')
 

--- a/src/stories/Components/Accordion/Accordion.mdx
+++ b/src/stories/Components/Accordion/Accordion.mdx
@@ -35,6 +35,20 @@ Accordion can be used as a standalone component, however, it does have a few dep
 @import '@rolemodel/optics/dist/css/components/accordion';
 ```
 
+## Features
+
+### Exclusive [open]
+
+Setting the `name` attribute on the `<details>` element will make the accordion exclusive. This attribute enables multiple `<details>` elements to be connected, with only one open at a time.
+
+See more about the `name` attribute on the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#name).
+
+```html
+<details class="accordion" name="accordion-group">...</details>
+<details class="accordion" name="accordion-group">...</details>
+<details class="accordion" name="accordion-group">...</details>
+```
+
 ## Variations
 
 ### Default

--- a/src/stories/Components/Accordion/Accordion.mdx
+++ b/src/stories/Components/Accordion/Accordion.mdx
@@ -52,6 +52,12 @@ Positioning the marker after the label inside of the summary will result in the 
 
 <Canvas of={AccordionStories.FlipHeaderAndMarker} />
 
+### Disable Animation
+
+If you prefer the accordion to not animate, you can disable the transition on the icon and content by using this modifier `.accordion--disable-animation`.
+
+<Canvas of={AccordionStories.DisableAnimation} />
+
 ### Additional Header Content
 
 Additional content can be included within the `summary` element in any order. Anything not within the `.accordion__label` or `.accordion__marker` classes will be rendered wherever you place it in the `summary`. Note: Content placed between the label and the marker will fill the width between them. If placing a button there, you may want to wrap it in a div so the button doesn't stretch the whole space.

--- a/src/stories/Components/Accordion/Accordion.stories.js
+++ b/src/stories/Components/Accordion/Accordion.stories.js
@@ -11,6 +11,7 @@ export default {
     marker: { control: 'text' },
     additionalHeaderContent: { control: 'text' },
     flipHeaderAndMarker: { control: 'boolean' },
+    disableAnimation: { control: 'boolean' },
     content: { control: 'text' },
   },
   parameters: {
@@ -25,6 +26,12 @@ export const Default = {
 export const FlipHeaderAndMarker = {
   args: {
     flipHeaderAndMarker: true,
+  },
+}
+
+export const DisableAnimation = {
+  args: {
+    disableAnimation: true,
   },
 }
 

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -4,10 +4,10 @@ export const createIcon = ({ name, filled = false, size = 'medium', weight = 'no
 
   icon.className = [
     'material-symbols-outlined',
-    filled ? 'icon--filled' : 'icon--outlined',
-    `icon--${size}`,
-    `icon--weight-${weight}`,
-    `icon--${emphasis}-emphasis`,
+    filled ? 'icon--filled' : '',
+    size === 'medium' ? '' : `icon--${size}`,
+    weight === 'normal' ? '' : `icon--weight-${weight}`,
+    emphasis === 'normal' ? '' : `icon--${emphasis}-emphasis`,
   ]
     .filter(Boolean)
     .join(' ')

--- a/src/stories/Tokens/Animation/Animation.stories.js
+++ b/src/stories/Tokens/Animation/Animation.stories.js
@@ -8,7 +8,14 @@ export default {
   argTypes: {
     speed: {
       control: { type: 'select' },
-      options: ['accordion (120ms)', 'input (120ms)', 'sidebar (200ms)', 'modal (300ms)', 'panel (400ms)'],
+      options: [
+        'accordion (120ms)',
+        'accordion_content (300ms)',
+        'input (120ms)',
+        'sidebar (200ms)',
+        'modal (300ms)',
+        'panel (400ms)',
+      ],
     },
   },
 }
@@ -46,5 +53,11 @@ export const Panel = {
 export const AccordionRotation = {
   args: {
     speed: 'accordion (120ms)',
+  },
+}
+
+export const AccordionContent = {
+  args: {
+    speed: 'accordion content (300ms)',
   },
 }


### PR DESCRIPTION
## Why?

With the following features gaining support in some browsers and having a graceful fallback (to existing behavior) for browsers that don't support it, animated accordions are now possible.

* https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#name
* https://developer.mozilla.org/en-US/docs/Web/CSS/::details-content

## What Changed

What changed in this PR?

- [X] Add token and documentation for accordion content transition
- [X] Add styles and documentation to animate or disable animation on accordions
- [X] Add documentation around Exclusive details with instruction on how to use it.

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

![Kapture 2025-02-08 at 16 10 23](https://github.com/user-attachments/assets/07feafda-2564-4bdd-9f43-718b639f2149)
![Kapture 2025-02-08 at 16 11 38](https://github.com/user-attachments/assets/07524fa1-2ba0-4ef4-a760-9f161be0627c)
![Kapture 2025-02-08 at 16 12 27](https://github.com/user-attachments/assets/a7cd7521-0633-4a7c-a62c-27a7fa381885)
<img width="1045" alt="Screenshot 2025-02-08 at 4 22 43 PM" src="https://github.com/user-attachments/assets/23e31ebb-6d01-48d2-a0dd-e046b3b6c0a6" />

