### PR TITLE
[OP-200] Move fonts to their own files

### DIFF
--- a/src/components/icon.css
+++ b/src/components/icon.css
@@ -1,12 +1,3 @@
-/*
-  Look up icons at: https://fonts.google.com/icons?icon.set=Material+Symbols
-  Instead of hosting the font files locally which requires the compiler to handle them, we pull the icons
-  from Googles CDN like we do for our other fonts
-  https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
-*/
-
-@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block';
-
 .material-symbols-outlined,
 .material-symbols {
   --op-mso-fill: 0;

--- a/src/core/fonts/icon_fonts.css
+++ b/src/core/fonts/icon_fonts.css
@@ -1,0 +1,11 @@
+/*
+  See all icons at: https://fonts.google.com/icons?icon.set=Material+Symbols
+  Material Symbols supports:
+  fill set through: font-variation-settings: 'FILL' {0|1}
+  font weight set through: font-variation-settings: 'wght' {100..900}
+  emphasis set through: font-variation-settings: 'GRAD' {-20|0|200}
+  optical sizing set through: font-variation-settings: 'opsz' {20|40|48}
+*/
+
+/* Material Symbols */
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block';

--- a/src/core/fonts/index.css
+++ b/src/core/fonts/index.css
@@ -1,0 +1,8 @@
+/*
+  Instead of hosting the font files locally which requires a compiler to handle them, we pull fonts
+  from Googles CDN. This does introduce a slight performance hit, but it's a tradeoff for simplicity.
+  https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
+*/
+
+@import 'text_fonts';
+@import 'icon_fonts';

--- a/src/core/fonts/text_fonts.css
+++ b/src/core/fonts/text_fonts.css
@@ -1,0 +1,16 @@
+/*
+Noto Sans supports:
+  font-weight: {anything between 100 and 900}
+  font-stretch: {anything between 62.5% and 100%}
+  font-style: {normal or italic}
+*/
+
+/*
+  Noto Serif supports:
+  font-weight: {anything between 100 and 900}
+  font-stretch: {anything between 62.5% and 100%}
+  font-style: {normal or italic}
+*/
+
+/* Noto Sans and Noto Serif */
+@import 'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&family=Noto+Serif:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&display=swap';

--- a/src/core/tokens/base_tokens.css
+++ b/src/core/tokens/base_tokens.css
@@ -1,19 +1,3 @@
-@import 'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&family=Noto+Serif:ital,wdth,wght@0,62.5..100,100..900;1,62.5..100,100..900&display=swap';
-
-/*
-Noto Sans supports:
-  font-weight: {anything between 100 and 900}
-  font-stretch: {anything between 62.5% and 100%}
-  font-style: {normal or italic}
-*/
-
-/*
-  Noto Serif supports:
-  font-weight: {anything between 100 and 900}
-  font-stretch: {anything between 62.5% and 100%}
-  font-style: {normal or italic}
-*/
-
 :root {
   /* Color HSLs
     A theme comprised of a primary, neutral, warning, danger, info, and notice colors.

--- a/src/optics.css
+++ b/src/optics.css
@@ -1,6 +1,9 @@
 /* Third party Vendors */
 @import 'modern-css-reset/dist/reset';
 
+/* Fonts */
+@import 'core/fonts';
+
 /* Tokens */
 @import 'core/tokens';
 

--- a/src/stories/Components/Accordion/Accordion.mdx
+++ b/src/stories/Components/Accordion/Accordion.mdx
@@ -27,6 +27,7 @@ Accordion can be used as a standalone component, however, it does have a few dep
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Alert/Alert.mdx
+++ b/src/stories/Components/Alert/Alert.mdx
@@ -144,7 +144,7 @@ This allows us to define core styles on a main [block](https://getbem.com/naming
 If you need to override the behavior of a particular alert style, you can open the respective class and set or change properties.
 
 ```css
-// This will only affect the warning alert, but not danger, info, or notice.
+/* This will only affect the warning alert, but not danger, info, or notice. */
 .alert--warning {
   background-color: red;
   color: white;

--- a/src/stories/Components/Alert/Alert.mdx
+++ b/src/stories/Components/Alert/Alert.mdx
@@ -29,6 +29,7 @@ Alert can be used as a standalone component, however, it does have a few depende
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Avatar/Avatar.mdx
+++ b/src/stories/Components/Avatar/Avatar.mdx
@@ -29,6 +29,7 @@ Avatar can be used as a standalone component, however, it does have a few depend
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Badge/Badge.mdx
+++ b/src/stories/Components/Badge/Badge.mdx
@@ -26,6 +26,7 @@ Badge can be used as a standalone component, however, it does have a few depende
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Badge/Badge.mdx
+++ b/src/stories/Components/Badge/Badge.mdx
@@ -108,7 +108,7 @@ This allows us to define core styles on a main [block](https://getbem.com/naming
 If you need to override the behavior of a particular badge style, you can open the respective class and set or change properties
 
 ```css
-// This will only affect the primary badge, but not default, secondary, notice, etc.
+/* This will only affect the primary badge, but not default, secondary, notice, etc. */
 .badge--primary {
   background-color: red;
   color: white;

--- a/src/stories/Components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/stories/Components/Breadcrumbs/Breadcrumbs.mdx
@@ -28,6 +28,7 @@ Breadcrumbs can be used as a standalone component, however, it does have a few d
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -26,6 +26,7 @@ Button can be used as a standalone component, however, it does have a few depend
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Button/Button.mdx
+++ b/src/stories/Components/Button/Button.mdx
@@ -115,7 +115,7 @@ Here are the variables and states used
 
 {/* prettier-ignore-start */}
 ```css
-// Variable API
+/* Variable API */
 --_op-btn-height-small
 --_op-btn-height-medium
 --_op-btn-height-large
@@ -128,13 +128,13 @@ Here are the variables and states used
 --_op-btn-padding-medium
 --_op-btn-padding-large
 
-// Different states
-.btn {} // Default behavior
-.btn:not(:disabled, .btn--disabled):hover {} // Hover behavior
-.btn.btn--no-border {} // No Border Modifier
-.btn.btn--no-border:not(:disabled, .btn--disabled):hover {} // Hovered No Border Modifier
-.btn.btn--active {} // Active Modifier
-.btn.btn--active:not(:disabled, .btn--disabled):hover {} // Hovered No Border Modifier
+/* Different states */
+.btn {} /* Default behavior */
+.btn:not(:disabled, .btn--disabled):hover {} /* Hover behavior  */
+.btn.btn--no-border {} /* No Border Modifier  */
+.btn.btn--no-border:not(:disabled, .btn--disabled):hover {} /* Hovered No Border Modifier  */
+.btn.btn--active {} /* Active Modifier  */
+.btn.btn--active:not(:disabled, .btn--disabled):hover {} /* Hovered No Border Modifier  */
 ```
 {/* prettier-ignore-end */}
 
@@ -180,7 +180,7 @@ If you want to override how the size modifier behaves, you can use API described
 If you need to override the color of a particular button style, you can open the respective class and change the `background-color`, `color`, and `box-shadow` properties to change the look.
 
 ```css
-// This will only affect the default button, but not primary, secondary, etc.
+/* This will only affect the default button, but not primary, secondary, etc. */
 .btn {
   background-color: red;
   color: white;

--- a/src/stories/Components/ButtonGroup/ButtonGroup.mdx
+++ b/src/stories/Components/ButtonGroup/ButtonGroup.mdx
@@ -25,6 +25,7 @@ Button Group can be used as a standalone component, however, it does have a few 
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Card/Card.mdx
+++ b/src/stories/Components/Card/Card.mdx
@@ -27,6 +27,7 @@ Card can be used as a standalone component, however, it does have a few dependen
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/ConfirmDialog/ConfirmDialog.mdx
+++ b/src/stories/Components/ConfirmDialog/ConfirmDialog.mdx
@@ -21,6 +21,7 @@ Confirm Dialog can be used as a standalone component, however, it does have a fe
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Divider/Divider.mdx
+++ b/src/stories/Components/Divider/Divider.mdx
@@ -26,6 +26,7 @@ Divider can be used as a standalone component, however, it does have a few depen
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Form/Form.mdx
+++ b/src/stories/Components/Form/Form.mdx
@@ -149,7 +149,7 @@ Here are the variables that can be customized.
 
 {/* prettier-ignore-start */}
 ```css
-// .form-control
+/* .form-control */
 --_op-form-control-height-small
 --_op-form-control-height-medium
 --_op-form-control-height-large
@@ -157,10 +157,10 @@ Here are the variables that can be customized.
 --_op-form-control-font-medium
 --_op-form-control-font-large
 
-// .form-control:not([type='radio'], [type='checkbox'])
+/* .form-control:not([type='radio'], [type='checkbox']) */
 --_op-form-control-opacity-disabled
 
-// .form-control:is([type='radio'], [type='checkbox'])
+/* .form-control:is([type='radio'], [type='checkbox']) */
 --_op-form-control-height-small
 --_op-form-control-height-medium
 --_op-form-control-height-large

--- a/src/stories/Components/Form/Form.mdx
+++ b/src/stories/Components/Form/Form.mdx
@@ -32,6 +32,7 @@ Form Controls can be used as standalone components, however, they do have a few 
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -25,6 +25,7 @@ Icon can be used as a standalone component, however, it does have a few dependen
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts'; /* (specifically core/fonts/icon_fonts) */
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Modal/Modal.mdx
+++ b/src/stories/Components/Modal/Modal.mdx
@@ -139,14 +139,14 @@ Here are the variables that can be customized:
 
 {/* prettier-ignore-start */}
 ```css
-// modal-wrapper
+/* modal-wrapper */
 --_op-modal-backdrop-active-opacity
 
-// modal
+/* modal */
 --_op-modal-width
 --_op-modal-max-height
 
-// dialog.modal::backdrop
+/* dialog.modal::backdrop */
 --op-color-black
 --_op-modal-backdrop-active-opacity
 ```

--- a/src/stories/Components/Modal/Modal.mdx
+++ b/src/stories/Components/Modal/Modal.mdx
@@ -21,6 +21,7 @@ Modal can be used as a standalone component, however, it does have a few depende
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Navbar/Navbar.mdx
+++ b/src/stories/Components/Navbar/Navbar.mdx
@@ -33,6 +33,7 @@ Navbar can be used as a standalone component, however, it does have a few depend
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Navbar/Navbar.mdx
+++ b/src/stories/Components/Navbar/Navbar.mdx
@@ -82,16 +82,16 @@ Here are the variables that can be customized.
 
 {/* prettier-ignore-start */}
 ```css
-// Public API
-// Normal
+/* Public API */
+/* Normal */
 --_op-navbar-background-color
 --_op-navbar-text-color
 --_op-navbar-border-color
 
-// Height
+/* Height */
 --_op-navbar-brand-height
 
-// Spacing
+/* Spacing */
 --_op-navbar-horizontal-spacing
 --_op-navbar-content-spacing
 --_op-navbar-content-item-spacing

--- a/src/stories/Components/Pagination/Pagination.mdx
+++ b/src/stories/Components/Pagination/Pagination.mdx
@@ -37,6 +37,7 @@ Pagination can be used as a standalone component, however, it does have a few de
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/core/button';

--- a/src/stories/Components/SidePanel/SidePanel.mdx
+++ b/src/stories/Components/SidePanel/SidePanel.mdx
@@ -41,6 +41,7 @@ Side Panel can be used as a standalone component, however, it does have a few de
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/SidePanel/SidePanel.mdx
+++ b/src/stories/Components/SidePanel/SidePanel.mdx
@@ -167,7 +167,7 @@ Your application may need a variation. To add one, just follow this template. No
 
 ```css
 .sidepanel--{name} {
-  --_op-side-panel-width: calc(108 * var(--op-size-unit)); // 432px
+  --_op-side-panel-width: calc(108 * var(--op-size-unit)); /* 432px */
   --_op-side-panel-header-padding: var(--op-space-large);
   --_op-side-panel-body-padding: var(--op-space-large);
   --_op-side-panel-footer-padding: var(--op-space-large);

--- a/src/stories/Components/Sidebar/Sidebar.mdx
+++ b/src/stories/Components/Sidebar/Sidebar.mdx
@@ -84,6 +84,7 @@ Sidebar can be used as a standalone component, however, it does have a few depen
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/Sidebar/Sidebar.mdx
+++ b/src/stories/Components/Sidebar/Sidebar.mdx
@@ -168,13 +168,13 @@ Color and hover styles are built on CSS variables scoped to the sidebar.
 Here are the variables used:
 
 ```css
-// Public API
-// Normal
+/* Public API */
+/* Normal */
 --_op-sidebar-background-color
 --_op-sidebar-text-color
 --_op-sidebar-border-color
 
-// Width
+/* Width */
 --_op-sidebar-rail-width
 --_op-sidebar-compact-width
 --_op-sidebar-drawer-width
@@ -182,13 +182,13 @@ Here are the variables used:
 --_op-sidebar-compact-brand-width
 --_op-sidebar-drawer-brand-width
 
-// Spacing
+/* Spacing */
 --_op-sidebar-spacing
 --_op-sidebar-brand-spacing
 --_op-sidebar-content-spacing
 --_op-sidebar-content-item-spacing
 
-// Animation
+/* Animation */
 --_op-sidebar-transition
 ```
 
@@ -236,7 +236,7 @@ There are also styles for the rail and drawer specific styles. They can be overr
 If you need to override the color of a particular sidebar style, you can open the respective class and change the variables documented above
 
 ```css
-// This will only affect the primary sidebar, but not default
+/* This will only affect the primary sidebar, but not default */
 .sidebar--primary {
   --_op-sidebar-background-color: purple;
   --_op-sidebar-text-color: purple;

--- a/src/stories/Components/Spinner/Spinner.mdx
+++ b/src/stories/Components/Spinner/Spinner.mdx
@@ -30,6 +30,7 @@ Spinner can be used as a standalone component, however, it does have a few depen
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Switch/Switch.mdx
+++ b/src/stories/Components/Switch/Switch.mdx
@@ -34,6 +34,7 @@ Switch can be used as a standalone component, however, it does have a few depend
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Tab/Tab.mdx
+++ b/src/stories/Components/Tab/Tab.mdx
@@ -26,6 +26,7 @@ Tab can be used as a standalone component, however, it does have a few dependenc
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Table/Table.mdx
+++ b/src/stories/Components/Table/Table.mdx
@@ -83,9 +83,9 @@ These are best used in conjunction with a wrapping container fixed table height,
 
 ```html
 <div class="table-container">
-  // Container div with class also needs to set the desired height. 20vh in these examples
+  <!-- Container div with class also needs to set the desired height. 20vh in these examples -->
   <table class="table">
-    // Actual table element ...
+    <!-- Actual table element ... -->
   </table>
 </div>
 ```
@@ -111,7 +111,7 @@ Padding table styles are built on CSS variables scoped to the table.
 Here are the variables used:
 
 ```css
-// Variable API
+/* Variable API */
 --_op-table-cell-padding-default
 --_op-table-cell-padding-comfortable
 --_op-table-cell-padding-compact

--- a/src/stories/Components/Table/Table.mdx
+++ b/src/stories/Components/Table/Table.mdx
@@ -26,6 +26,7 @@ Table can be used as a standalone component, however, it does have a few depende
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Tag/Tag.mdx
+++ b/src/stories/Components/Tag/Tag.mdx
@@ -28,6 +28,7 @@ Tag can be used as a standalone component, however, it does have a few dependenc
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 @import '@rolemodel/optics/dist/css/components/icon';

--- a/src/stories/Components/TextPair/TextPair.mdx
+++ b/src/stories/Components/TextPair/TextPair.mdx
@@ -26,6 +26,7 @@ Text Pair can be used as a standalone component, however, it does have a few dep
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Tooltip/Tooltip.mdx
+++ b/src/stories/Components/Tooltip/Tooltip.mdx
@@ -38,6 +38,7 @@ Tooltip can be used as a standalone component, however, it does have a few depen
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 

--- a/src/stories/Components/Tooltip/Tooltip.mdx
+++ b/src/stories/Components/Tooltip/Tooltip.mdx
@@ -156,6 +156,6 @@ Your application may need a variation. To add one, just follow this template. No
 
 ```css
 [data-special-tooltip-text] {
-  // Add your custom styles here
+  /* Add your custom styles here */
 }
 ```

--- a/src/stories/Overview/FileOrganization.mdx
+++ b/src/stories/Overview/FileOrganization.mdx
@@ -34,31 +34,35 @@ The recommended folder structure is to have a `main or application` file that is
 Using the above folder structure, the application file should import all of the other files. Comments can be used to describe the purpose of each section of files.
 
 ```css
-// Optics
+/* Optics */
 @import '@rolemodel/optics';
 
-// Vendors
+/* Vendors */
 @import 'something-from-node-modules/something';
 
-// Theme Customization
+/* Font Customization */
+@import 'core/fonts/text_fonts';
+@import 'core/fonts/icon_fonts';
+
+/* Theme Customization */
 @import 'core/theme/{name}-theme-core';
 @import 'core/theme/{name}-theme-light';
 @import 'core/theme/{name}-theme-dark';
 
-// Core Customization
+/* Core Customization */
 @import 'core/base';
 @import 'core/layout';
 @import 'core/utilities';
 
-// Vendor Customization
+/* Vendor Customization */
 @import 'vendors/{vendor-name}-overrides';
 
-// Optics Component Customization
+/* Optics Component Customization */
 @import 'components/optics-overrides/{component-name}';
 
 /* Component */
 @import 'components/{component-name}';
 
-// General Styles
+/* General Styles */
 @import 'general/{general-name}';
 ```

--- a/src/stories/Overview/SelectiveImports.mdx
+++ b/src/stories/Overview/SelectiveImports.mdx
@@ -16,15 +16,21 @@ By default, when you import the design system, it will include the basics. CSS r
 If your application doesn't need all styles provided, you can import only the files you need like this:
 
 ```css
+/* Third party Vendors */
 @import 'modern-css-reset/dist/reset';
 
+/* Fonts */
+@import 'core/fonts';
+
+/* Tokens */
 @import 'core/tokens';
 
+/* Base styles and utilities */
 @import 'core/base';
 @import 'core/layout';
 @import 'core/utilities';
 
-// Just the button and card Components
+/* Just the button and card Components */
 @import 'components/button';
 @import 'components/card';
 ```
@@ -32,16 +38,21 @@ If your application doesn't need all styles provided, you can import only the fi
 Or this:
 
 ```css
+/* Third party Vendors */
 @import 'modern-css-reset/dist/reset';
 
-@import 'base_tokens';
-@import 'scale_color_tokens';
-// No dark mode or alert tokens
+/* No Material Icons */
+@import 'core/fonts/text_fonts';
 
+/* Tokens */
+@import 'core/tokens';
+
+/* Base styles and utilities */
 @import 'core/base';
 @import 'core/layout';
 @import 'core/utilities';
 
+/* Components */
 @import 'components';
 ```
 

--- a/src/stories/Overview/SelectiveImports.mdx
+++ b/src/stories/Overview/SelectiveImports.mdx
@@ -9,7 +9,7 @@ By default, when you import the design system, it will include the basics. CSS r
 
 ```css
 @import '@rolemodel/optics';
-// or
+/* or */
 @import '@rolemodel/optics/dist/css/optics';
 ```
 

--- a/src/stories/Recipes/AlignedHeader/AlignedHeader.mdx
+++ b/src/stories/Recipes/AlignedHeader/AlignedHeader.mdx
@@ -26,9 +26,9 @@ This is not a common problem and your particular use-case may need to tweak the 
 ## Badge Example
 
 ```css
-// Badge Example
+/* Badge Example */
 .aligned-header {
-  // Public API (allowed to be overridden)
+  /* Public API (allowed to be overridden) */
   --_op-line-height: var(--op-line-height-base);
   --_op-font-size: var(--op-font-4x-large);
 

--- a/src/stories/Tokens/Animation/Animation.mdx
+++ b/src/stories/Tokens/Animation/Animation.mdx
@@ -26,7 +26,7 @@ These tokens can be applied as a transition.
 
 ```css
 transition: var(--op-transition-input);
-// or
+/* or */
 animation: var(--op-animation-flash);
 ```
 

--- a/src/stories/Tokens/Border/BorderStroke.mdx
+++ b/src/stories/Tokens/Border/BorderStroke.mdx
@@ -21,7 +21,7 @@ These tokens can be applied as a box shadow with any color you wish.
 
 ```css
 box-shadow: var(--op-border-all) var(--op-color-border);
-// or
+/* or */
 box-shadow: var(--op-border-left) var(--op-color-primary-base);
 ```
 
@@ -31,7 +31,7 @@ box-shadow: var(--op-border-left) var(--op-color-primary-base);
 
 ```css
 box-shadow: inset var(--op-border-all) var(--op-color-border);
-// or
+/* or */
 box-shadow: inset var(--op-border-left) var(--op-color-primary-base);
 ```
 

--- a/src/stories/Tokens/Border/BorderWidth.mdx
+++ b/src/stories/Tokens/Border/BorderWidth.mdx
@@ -20,7 +20,7 @@ These tokens can be applied with a border or box shadow.
 
 ```css
 border-width: 0 0 0 var(--op-border-width);
-// or
+/* or */
 box-shadow: 0 0 0 var(--op-border-width);
 ```
 

--- a/src/stories/Tokens/Breakpoint.mdx
+++ b/src/stories/Tokens/Breakpoint.mdx
@@ -47,7 +47,7 @@ These token values can be applied in a media query to create responsive behavior
   */
 }
 
-// --op-breakpoint-medium
+/* --op-breakpoint-medium */
 @media (width > 1024px) {
   background-color: var(--op-color-primary-base);
   color: var(--op-color-primary-on-base);

--- a/src/stories/Tokens/Color/BasicColor.mdx
+++ b/src/stories/Tokens/Color/BasicColor.mdx
@@ -25,7 +25,7 @@ body {
   background-color: var(--op-color-background);
   color: var(--op-color-on-background);
 }
-// or
+/* or */
 color: var(--op-color-white);
 ```
 

--- a/src/stories/Tokens/Color/BorderColor.mdx
+++ b/src/stories/Tokens/Color/BorderColor.mdx
@@ -20,7 +20,7 @@ These tokens can be applied with a border or box shadow.
 
 ```css
 border-color: var(--op-color-border);
-// or
+/* or */
 box-shadow: var(--op-border-top) var(--op-color-border);
 ```
 

--- a/src/stories/Tokens/Color/ColorWithAlpha.mdx
+++ b/src/stories/Tokens/Color/ColorWithAlpha.mdx
@@ -29,9 +29,11 @@ Since colors are based on a scale and provided as tokens, the alpha channel cann
 One option for adding alpha support is to define alpha tokens that can sit alongside the color scale steps. This allows for use across your system in a way that matches the system.
 
 ```css
-// Note the 40% luminoisty matches the --op-color-primary-base luminosity
-// Note the 100% luminoisty matches the --op-color-primary-on-base luminosity
-// Note the 88% luminoisty matches the --op-color-primary-on-base-alt luminosity
+/*
+  Note the 40% luminoisty matches the --op-color-primary-base luminosity
+  Note the 100% luminoisty matches the --op-color-primary-on-base luminosity
+  Note the 88% luminoisty matches the --op-color-primary-on-base-alt luminosity
+*/
 
 --op-color-primary-base-alpha-40: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 40% / 40%);
 --op-color-primary-on-base-alpha-40: hsl(var(--op-color-primary-h) var(--op-color-primary-s) 100% / 40%);
@@ -61,11 +63,23 @@ Another option is to use the `color-mix` (see [color-mix()](https://developer.mo
 
 ```css
 %my-component-global {
-  --_op-my-component-opacity-disabled: calc(var(--op-opacity-disabled) * 100%); // converts 0.4 to 40%
+  --_op-my-component-opacity-disabled: calc(var(--op-opacity-disabled) * 100%); /* converts 0.4 to 40% */
 
-  --op-my-component-background-color: color-mix(in srgv, var(--op-color-primary-base) var(--_op-thing-opacity-disabled), var(--op-color-primary-plus-max));
-  --op-my-component-color: color-mix(in srgv, var(--op-color-primary-on-base) var(--_op-thing-opacity-disabled), var(--op-color-primary-plus-max));
-  --op-my-component-color-alt: color-mix(in srgv, var(--op-color-primary-on-base-alt) var(--_op-thing-opacity-disabled), var(--op-color-primary-plus-max));
+  --op-my-component-background-color: color-mix(
+    in srgv,
+    var(--op-color-primary-base) var(--_op-thing-opacity-disabled),
+    var(--op-color-primary-plus-max)
+  );
+  --op-my-component-color: color-mix(
+    in srgv,
+    var(--op-color-primary-on-base) var(--_op-thing-opacity-disabled),
+    var(--op-color-primary-plus-max)
+  );
+  --op-my-component-color-alt: color-mix(
+    in srgv,
+    var(--op-color-primary-on-base-alt) var(--_op-thing-opacity-disabled),
+    var(--op-color-primary-plus-max)
+  );
 
   background-color: var(--op-my-component-background-color);
   color: var(--op-my-component-color);

--- a/src/stories/Tokens/Input/InputHeight.mdx
+++ b/src/stories/Tokens/Input/InputHeight.mdx
@@ -13,9 +13,9 @@ These tokens can be applied to anything that requires a users input and needs a 
 
 ```css
 height: var(--op-input-height-large);
-// or
+/* or */
 max-height: var(--op-input-height-small);
-// or
+/* or */
 min-height: var(--op-input-height-medium);
 ```
 

--- a/src/stories/Tokens/Opacity.mdx
+++ b/src/stories/Tokens/Opacity.mdx
@@ -20,7 +20,7 @@ These tokens can be applied as opacities.
 
 ```css
 opacity: var(--op-opacity-disabled);
-// or
+/* or */
 opacity: var(--op-opacity-full);
 ```
 

--- a/src/stories/Tokens/Shadow.mdx
+++ b/src/stories/Tokens/Shadow.mdx
@@ -20,7 +20,7 @@ These tokens can be applied as box shadows.
 
 ```css
 box-shadow: var(--op-shadow-x-small);
-// or
+/* or */
 box-shadow: var(--op-shadow-x-large);
 ```
 

--- a/src/stories/Tokens/Sizing.mdx
+++ b/src/stories/Tokens/Sizing.mdx
@@ -19,9 +19,9 @@ The Size token enables creating scalable widths and heights for your application
 These tokens can be applied like:
 
 ```css
-height: calc(11 * var(--op-size-unit)); // 44px
+height: calc(11 * var(--op-size-unit)); /* 44px */
 /* Or */
-width: calc(54 * var(--op-size-unit)); // 216px
+width: calc(54 * var(--op-size-unit)); /* 216px */
 ```
 
 ## Available tokens and their definitions

--- a/src/stories/Tokens/Typography/FontFamily.mdx
+++ b/src/stories/Tokens/Typography/FontFamily.mdx
@@ -57,38 +57,38 @@ For example: [Roboto Flex](https://fonts.google.com/specimen/Roboto+Flex) has th
 
 ```css
 /*
-  <uniquifier>: Use a unique and descriptive class name
-  <weight>: Use a value from 100 to 1000
-  <grade>: Use a value from -200 to 150
-  <slant>: Use a value from -10 to 0
-  <width>: Use a value from 25 to 151
-  <thick stroke>: Use a value from 27 to 175
-  <thin stroke>: Use a value from 25 to 135
-  <counter width>: Use a value from 323 to 603
-  <uppercase height>: Use a value from 528 to 760
-  <lowercase height>: Use a value from 416 to 570
-  <ascender height>: Use a value from 649 to 854
-  <descender depth>: Use a value from -305 to -98
-  <figure height>: Use a value from 560 to 788
+  {uniquifier}: Use a unique and descriptive class name
+  {weight}: Use a value from 100 to 1000
+  {grade}: Use a value from -200 to 150
+  {slant}: Use a value from -10 to 0
+  {width}: Use a value from 25 to 151
+  {thick stroke}: Use a value from 27 to 175
+  {thin stroke}: Use a value from 25 to 135
+  {counter width}: Use a value from 323 to 603
+  {uppercase height}: Use a value from 528 to 760
+  {lowercase height}: Use a value from 416 to 570
+  {ascender height}: Use a value from 649 to 854
+  {descender depth}: Use a value from -305 to -98
+  {figure height}: Use a value from 560 to 788
 */
 
-.roboto-flex-<uniquifier > {
+.roboto-flex-{uniquifier} {
   font-family: 'Roboto Flex', sans-serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: {weight};
   font-style: normal;
   font-variation-settings:
-    'slnt' <slant>,
-    'wdth' <width>,
-    'GRAD' <grade>,
-    'XOPQ' <thick stroke>,
-    'XTRA' <counter width>,
-    'YOPQ' <thin stroke>,
-    'YTAS' <ascender height>,
-    'YTDE' <descender depth>,
-    'YTFI' <figure height>,
-    'YTLC' <lowercase height>,
-    'YTUC' <uppercase height>;
+    'slnt' {slant},
+    'wdth' {width},
+    'GRAD' {grade},
+    'XOPQ' {thick stroke},
+    'XTRA' {counter width},
+    'YOPQ' {thin stroke},
+    'YTAS' {ascender height},
+    'YTDE' {descender depth},
+    'YTFI' {figure height},
+    'YTLC' {lowercase height},
+    'YTUC' {uppercase height};
 }
 ```
 

--- a/src/stories/Tokens/Typography/FontFamily.mdx
+++ b/src/stories/Tokens/Typography/FontFamily.mdx
@@ -39,14 +39,14 @@ Optics uses Noto Sans as a default which has three axes of variations: weight, w
 
 ```css
 .my-selector {
-  font-family: var(--op-font-family); // Defaults to "Noto Sans"
+  font-family: var(--op-font-family); /* Defaults to "Noto Sans" */
   font-optical-sizing: {auto|none};
-  font-weight: {100 to 900}; // Any value will work, though it is recommended to use the existing weight tokens or define a component specific value.
-  // E.G. font-weight: var(--op-font-weight-bold);
+  font-weight: {100 to 900}; /* Any value will work, though it is recommended to use the existing weight tokens or define a component specific value. */
+  /* E.G. font-weight: var(--op-font-weight-bold); */
   font-style: {normal|italic};
   font-variation-settings:
     "wdth" {62.5 to 100};
-  // or
+  /* or */
   font-stretch: {62.5% to 100%};
 }
 ```
@@ -56,21 +56,23 @@ If you are using a custom font, you can adjust the axes of the font by using the
 For example: [Roboto Flex](https://fonts.google.com/specimen/Roboto+Flex) has the following axes.
 
 ```css
-// <uniquifier>: Use a unique and descriptive class name
-// <weight>: Use a value from 100 to 1000
-// <grade>: Use a value from -200 to 150
-// <slant>: Use a value from -10 to 0
-// <width>: Use a value from 25 to 151
-// <thick stroke>: Use a value from 27 to 175
-// <thin stroke>: Use a value from 25 to 135
-// <counter width>: Use a value from 323 to 603
-// <uppercase height>: Use a value from 528 to 760
-// <lowercase height>: Use a value from 416 to 570
-// <ascender height>: Use a value from 649 to 854
-// <descender depth>: Use a value from -305 to -98
-// <figure height>: Use a value from 560 to 788
+/*
+  <uniquifier>: Use a unique and descriptive class name
+  <weight>: Use a value from 100 to 1000
+  <grade>: Use a value from -200 to 150
+  <slant>: Use a value from -10 to 0
+  <width>: Use a value from 25 to 151
+  <thick stroke>: Use a value from 27 to 175
+  <thin stroke>: Use a value from 25 to 135
+  <counter width>: Use a value from 323 to 603
+  <uppercase height>: Use a value from 528 to 760
+  <lowercase height>: Use a value from 416 to 570
+  <ascender height>: Use a value from 649 to 854
+  <descender depth>: Use a value from -305 to -98
+  <figure height>: Use a value from 560 to 788
+*/
 
-.roboto-flex-<uniquifier> {
+.roboto-flex-<uniquifier > {
   font-family: 'Roboto Flex', sans-serif;
   font-optical-sizing: auto;
   font-weight: <weight>;

--- a/src/stories/Tokens/Typography/FontFamily.mdx
+++ b/src/stories/Tokens/Typography/FontFamily.mdx
@@ -110,7 +110,7 @@ If you want to change the font used by default, you can add a new font import to
 
 ## Alternate or Multiple Fonts
 
-Often an application will need multiple fonts. Your headers may use a different font than your body text. Optics provides a single font family token, but you can easily add your own font tokens by following the pattern.
+Often an application will need multiple fonts. Your headers may use a different font than your body text. Optics provides a main token `--op-font-family` and an alt token `--op-font-family-alt`, but you can easily add your own font tokens by following the pattern.
 
 ```css
 @import 'https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,slnt,wdth,wght,GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC@8..144,-10..0,25..151,100..1000,-200..150,27..175,323..603,25..135,649..854,-305..-98,560..788,416..570,528..760&family=Tilt+Neon:XROT,YROT@-45..45,-45..45&display=swap';
@@ -118,7 +118,8 @@ Often an application will need multiple fonts. Your headers may use a different 
 :root {
   --op-font-family: 'Tilt Neon', sans-serif;
   --op-font-family-alt: 'Roboto Flex', serif;
-  // Could add others as needed
-  --ya-font-family-body: 'Roboto Flex', serif;  // Your App prefix. Could stick with --op if you want
+
+  /* Could add others as needed */
+  --ya-font-family-body: 'Roboto Flex', serif; /* Your App prefix. Could stick with --op if you want */
 }
 ```

--- a/src/stories/Utilities/Gap/Gap.mdx
+++ b/src/stories/Utilities/Gap/Gap.mdx
@@ -26,7 +26,7 @@ When using a gap utility, `--op-gap` will be set to the same spacing value as ga
 ```css
 .special-item {
   display: flex;
-  gap: var(--op-gap, var(--op-space-sm)); // Include a fallback in case the wrapping gap is missing.
+  gap: var(--op-gap, var(--op-space-sm)); /* Include a fallback in case the wrapping gap is missing. */
 }
 ```
 

--- a/src/stories/assets/dependency-graph.svg
+++ b/src/stories/assets/dependency-graph.svg
@@ -2,360 +2,360 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1634pt" height="260pt" viewBox="0.00 0.00 1634.16 260.00">
 <g id="graph0" class="graph" transform="translate(4,256) scale(1)" data-name="dependencies">
 
-<polygon fill="white" stroke="none" points="-4,4 -4,-256 1630.16,-256 1630.16,4 -4,4" style=""/>
+<polygon fill="white" stroke="none" points="-4,4 -4,-256 1630.16,-256 1630.16,4 -4,4"/>
 <!-- Tokens &amp; Base -->
-<g id="node1" class="node" pointer-events="visible" data-name="Tokens &amp; Base">
+<g id="node1" class="node" pointer-events="visible" data-name="Fonts, Tokens, Base" data-comment="Tokens &amp; Base">
 
-<polygon fill="none" stroke="black" points="694.86,-36 592.23,-36 592.23,0 694.86,0 694.86,-36" style=""/>
-<text text-anchor="middle" x="643.54" y="-13.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Tokens &amp; Base</text>
+<polygon fill="none" stroke="black" points="708.1,-36 578.99,-36 578.99,0 708.1,0 708.1,-36"/>
+<text text-anchor="middle" x="643.54" y="-13.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Fonts, Tokens, Base</text>
 </g>
 <!-- Accordion -->
 <g id="node2" class="node" pointer-events="visible" data-name="Accordion">
 
-<polygon fill="none" stroke="black" points="75.13,-180 -0.04,-180 -0.04,-144 75.13,-144 75.13,-180" style=""/>
-<text text-anchor="middle" x="37.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Accordion</text>
+<polygon fill="none" stroke="black" points="75.13,-180 -0.04,-180 -0.04,-144 75.13,-144 75.13,-180"/>
+<text text-anchor="middle" x="37.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Accordion</text>
 </g>
 <!-- Accordion&#45;&gt;Tokens &amp; Base -->
-<g id="edge1" class="edge" data-name="Accordion-&gt;Tokens &amp; Base">
+<g id="edge1" class="edge" data-name="Accordion-&gt;Fonts, Tokens, Base" data-comment="Accordion-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M51.32,-143.76C69.18,-122.78 102.49,-88.15 139.54,-72 217.3,-38.1 463.87,-25.2 580.83,-20.9" style=""/>
-<polygon fill="black" stroke="black" points="580.69,-24.4 590.56,-20.55 580.44,-17.41 580.69,-24.4" style=""/>
+<path fill="none" stroke="black" d="M51.32,-143.76C69.18,-122.78 102.49,-88.15 139.54,-72 214.45,-39.34 446.02,-26.17 567.45,-21.41"/>
+<polygon fill="black" stroke="black" points="567.48,-24.91 577.34,-21.03 567.21,-17.91 567.48,-24.91"/>
 </g>
 <!-- Icon -->
 <g id="node3" class="node" pointer-events="visible" data-name="Icon">
 
-<polygon fill="none" stroke="black" points="253.54,-108 199.54,-108 199.54,-72 253.54,-72 253.54,-108" style=""/>
-<text text-anchor="middle" x="226.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Icon</text>
+<polygon fill="none" stroke="black" points="253.54,-108 199.54,-108 199.54,-72 253.54,-72 253.54,-108"/>
+<text text-anchor="middle" x="226.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Icon</text>
 </g>
 <!-- Accordion&#45;&gt;Icon -->
 <g id="edge2" class="edge" data-name="Accordion-&gt;Icon">
 
-<path fill="none" stroke="black" d="M75.34,-147C108.24,-134.82 155.71,-117.24 188.65,-105.04" style=""/>
-<polygon fill="black" stroke="black" points="189.64,-108.4 197.8,-101.65 187.2,-101.84 189.64,-108.4" style=""/>
+<path fill="none" stroke="black" d="M75.34,-147C108.24,-134.82 155.71,-117.24 188.65,-105.04"/>
+<polygon fill="black" stroke="black" points="189.64,-108.4 197.8,-101.65 187.2,-101.84 189.64,-108.4"/>
 </g>
 <!-- Icon&#45;&gt;Tokens &amp; Base -->
-<g id="edge26" class="edge" data-name="Icon-&gt;Tokens &amp; Base">
+<g id="edge26" class="edge" data-name="Icon-&gt;Fonts, Tokens, Base" data-comment="Icon-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M254,-76.51C258.46,-74.8 263.08,-73.22 267.54,-72 375.37,-42.56 505.3,-28.87 580.75,-22.98" style=""/>
-<polygon fill="black" stroke="black" points="580.72,-26.49 590.42,-22.25 580.19,-19.51 580.72,-26.49" style=""/>
+<path fill="none" stroke="black" d="M254,-76.51C258.46,-74.8 263.08,-73.22 267.54,-72 369.17,-44.25 490.43,-30.49 567.21,-24.07"/>
+<polygon fill="black" stroke="black" points="567.48,-27.56 577.17,-23.26 566.92,-20.59 567.48,-27.56"/>
 </g>
 <!-- Alert -->
 <g id="node4" class="node" pointer-events="visible" data-name="Alert">
 
-<polygon fill="none" stroke="black" points="147.54,-180 93.54,-180 93.54,-144 147.54,-144 147.54,-180" style=""/>
-<text text-anchor="middle" x="120.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Alert</text>
+<polygon fill="none" stroke="black" points="147.54,-180 93.54,-180 93.54,-144 147.54,-144 147.54,-180"/>
+<text text-anchor="middle" x="120.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Alert</text>
 </g>
 <!-- Alert&#45;&gt;Tokens &amp; Base -->
-<g id="edge3" class="edge" data-name="Alert-&gt;Tokens &amp; Base">
+<g id="edge3" class="edge" data-name="Alert-&gt;Fonts, Tokens, Base" data-comment="Alert-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M126.03,-143.58C133.58,-122.75 149.31,-88.63 175.54,-72 241.41,-30.24 468.95,-21.29 580.67,-19.44" style=""/>
-<polygon fill="black" stroke="black" points="580.62,-22.94 590.57,-19.29 580.52,-15.94 580.62,-22.94" style=""/>
+<path fill="none" stroke="black" d="M126.03,-143.58C133.58,-122.75 149.31,-88.63 175.54,-72 238.95,-31.8 452.21,-22 567.7,-19.67"/>
+<polygon fill="black" stroke="black" points="567.46,-23.18 577.39,-19.49 567.33,-16.18 567.46,-23.18"/>
 </g>
 <!-- Alert&#45;&gt;Icon -->
 <g id="edge4" class="edge" data-name="Alert-&gt;Icon">
 
-<path fill="none" stroke="black" d="M147.02,-143.52C160.27,-134.76 176.51,-124.04 190.84,-114.58" style=""/>
-<polygon fill="black" stroke="black" points="192.73,-117.53 199.14,-109.09 188.87,-111.68 192.73,-117.53" style=""/>
+<path fill="none" stroke="black" d="M147.02,-143.52C160.27,-134.76 176.51,-124.04 190.84,-114.58"/>
+<polygon fill="black" stroke="black" points="192.73,-117.53 199.14,-109.09 188.87,-111.68 192.73,-117.53"/>
 </g>
 <!-- Badge -->
 <g id="node5" class="node" pointer-events="visible" data-name="Badge">
 
-<polygon fill="none" stroke="black" points="219.54,-180 165.54,-180 165.54,-144 219.54,-144 219.54,-180" style=""/>
-<text text-anchor="middle" x="192.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Badge</text>
+<polygon fill="none" stroke="black" points="219.54,-180 165.54,-180 165.54,-144 219.54,-144 219.54,-180"/>
+<text text-anchor="middle" x="192.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Badge</text>
 </g>
 <!-- Badge&#45;&gt;Tokens &amp; Base -->
-<g id="edge5" class="edge" data-name="Badge-&gt;Tokens &amp; Base">
+<g id="edge5" class="edge" data-name="Badge-&gt;Fonts, Tokens, Base" data-comment="Badge-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M185.88,-143.56C179.54,-123.66 173.28,-91.4 190.54,-72 216.02,-43.38 461.93,-27.74 580.38,-21.81" style=""/>
-<polygon fill="black" stroke="black" points="580.45,-25.31 590.26,-21.33 580.1,-18.32 580.45,-25.31" style=""/>
+<path fill="none" stroke="black" d="M185.88,-143.56C179.54,-123.66 173.28,-91.4 190.54,-72 215.14,-44.36 445.31,-28.83 567.75,-22.46"/>
+<polygon fill="black" stroke="black" points="567.58,-25.97 577.38,-21.96 567.22,-18.98 567.58,-25.97"/>
 </g>
 <!-- Badge&#45;&gt;Icon -->
 <g id="edge6" class="edge" data-name="Badge-&gt;Icon">
 
-<path fill="none" stroke="black" d="M200.95,-143.7C204.66,-136.07 209.1,-126.92 213.24,-118.4" style=""/>
-<polygon fill="black" stroke="black" points="216.36,-119.99 217.58,-109.47 210.06,-116.93 216.36,-119.99" style=""/>
+<path fill="none" stroke="black" d="M200.95,-143.7C204.66,-136.07 209.1,-126.92 213.24,-118.4"/>
+<polygon fill="black" stroke="black" points="216.36,-119.99 217.58,-109.47 210.06,-116.93 216.36,-119.99"/>
 </g>
 <!-- Button -->
 <g id="node6" class="node" pointer-events="visible" data-name="Button">
 
-<polygon fill="none" stroke="black" points="439.66,-180 385.43,-180 385.43,-144 439.66,-144 439.66,-180" style=""/>
-<text text-anchor="middle" x="412.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Button</text>
+<polygon fill="none" stroke="black" points="439.66,-180 385.43,-180 385.43,-144 439.66,-144 439.66,-180"/>
+<text text-anchor="middle" x="412.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Button</text>
 </g>
 <!-- Button&#45;&gt;Tokens &amp; Base -->
-<g id="edge7" class="edge" data-name="Button-&gt;Tokens &amp; Base">
+<g id="edge7" class="edge" data-name="Button-&gt;Fonts, Tokens, Base" data-comment="Button-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M415.95,-143.61C420.8,-123.46 431.66,-90.64 453.54,-72 488.97,-41.82 540.33,-28.75 580.72,-23.12" style=""/>
-<polygon fill="black" stroke="black" points="581.08,-26.6 590.57,-21.88 580.21,-19.66 581.08,-26.6" style=""/>
+<path fill="none" stroke="black" d="M415.95,-143.61C420.8,-123.46 431.66,-90.64 453.54,-72 485.22,-45.02 529.63,-31.71 567.55,-25.17"/>
+<polygon fill="black" stroke="black" points="567.75,-28.68 577.08,-23.66 566.65,-21.77 567.75,-28.68"/>
 </g>
 <!-- Button&#45;&gt;Icon -->
 <g id="edge8" class="edge" data-name="Button-&gt;Icon">
 
-<path fill="none" stroke="black" d="M385.1,-150.67C353.14,-138.64 300.16,-118.7 264.33,-105.22" style=""/>
-<polygon fill="black" stroke="black" points="265.81,-102.04 255.22,-101.79 263.34,-108.59 265.81,-102.04" style=""/>
+<path fill="none" stroke="black" d="M385.1,-150.67C353.14,-138.64 300.16,-118.7 264.33,-105.22"/>
+<polygon fill="black" stroke="black" points="265.81,-102.04 255.22,-101.79 263.34,-108.59 265.81,-102.04"/>
 </g>
 <!-- Tag -->
 <g id="node7" class="node" pointer-events="visible" data-name="Tag">
 
-<polygon fill="none" stroke="black" points="291.54,-180 237.54,-180 237.54,-144 291.54,-144 291.54,-180" style=""/>
-<text text-anchor="middle" x="264.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Tag</text>
+<polygon fill="none" stroke="black" points="291.54,-180 237.54,-180 237.54,-144 291.54,-144 291.54,-180"/>
+<text text-anchor="middle" x="264.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tag</text>
 </g>
 <!-- Tag&#45;&gt;Tokens &amp; Base -->
-<g id="edge9" class="edge" data-name="Tag-&gt;Tokens &amp; Base">
+<g id="edge9" class="edge" data-name="Tag-&gt;Fonts, Tokens, Base" data-comment="Tag-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M267.51,-143.52C271.96,-122.97 282.47,-89.44 305.54,-72 347.73,-40.11 494.76,-26.94 580.37,-21.88" style=""/>
-<polygon fill="black" stroke="black" points="580.47,-25.38 590.26,-21.32 580.08,-18.39 580.47,-25.38" style=""/>
+<path fill="none" stroke="black" d="M267.51,-143.52C271.96,-122.97 282.47,-89.44 305.54,-72 345.68,-41.66 480.69,-28.27 567.45,-22.68"/>
+<polygon fill="black" stroke="black" points="567.55,-26.18 577.32,-22.06 567.12,-19.19 567.55,-26.18"/>
 </g>
 <!-- Tag&#45;&gt;Icon -->
 <g id="edge10" class="edge" data-name="Tag-&gt;Icon">
 
-<path fill="none" stroke="black" d="M255.15,-143.7C250.96,-135.98 245.93,-126.71 241.26,-118.11" style=""/>
-<polygon fill="black" stroke="black" points="244.4,-116.55 236.55,-109.43 238.25,-119.89 244.4,-116.55" style=""/>
+<path fill="none" stroke="black" d="M255.15,-143.7C250.96,-135.98 245.93,-126.71 241.26,-118.11"/>
+<polygon fill="black" stroke="black" points="244.4,-116.55 236.55,-109.43 238.25,-119.89 244.4,-116.55"/>
 </g>
 <!-- Button Group -->
 <g id="node8" class="node" pointer-events="visible" data-name="Button Group">
 
-<polygon fill="none" stroke="black" points="344.44,-252 250.65,-252 250.65,-216 344.44,-216 344.44,-252" style=""/>
-<text text-anchor="middle" x="297.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Button Group</text>
+<polygon fill="none" stroke="black" points="344.44,-252 250.65,-252 250.65,-216 344.44,-216 344.44,-252"/>
+<text text-anchor="middle" x="297.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Button Group</text>
 </g>
 <!-- Button Group&#45;&gt;Tokens &amp; Base -->
-<g id="edge11" class="edge" data-name="Button Group-&gt;Tokens &amp; Base">
+<g id="edge11" class="edge" data-name="Button Group-&gt;Fonts, Tokens, Base" data-comment="Button Group-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M302.01,-215.71C311.59,-182.25 337.44,-108.73 387.54,-72 417.74,-49.87 515.31,-34.25 580.9,-25.94" style=""/>
-<polygon fill="black" stroke="black" points="580.94,-29.47 590.44,-24.76 580.08,-22.52 580.94,-29.47" style=""/>
+<path fill="none" stroke="black" d="M302.01,-215.71C311.59,-182.25 337.44,-108.73 387.54,-72 415.69,-51.37 502.38,-36.4 567.14,-27.74"/>
+<polygon fill="black" stroke="black" points="567.59,-31.21 577.05,-26.44 566.68,-24.27 567.59,-31.21"/>
 </g>
 <!-- Button Group&#45;&gt;Button -->
 <g id="edge12" class="edge" data-name="Button Group-&gt;Button">
 
-<path fill="none" stroke="black" d="M326.27,-215.52C341.14,-206.46 359.48,-195.3 375.42,-185.6" style=""/>
-<polygon fill="black" stroke="black" points="376.97,-188.75 383.69,-180.57 373.33,-182.78 376.97,-188.75" style=""/>
+<path fill="none" stroke="black" d="M326.27,-215.52C341.14,-206.46 359.48,-195.3 375.42,-185.6"/>
+<polygon fill="black" stroke="black" points="376.97,-188.75 383.69,-180.57 373.33,-182.78 376.97,-188.75"/>
 </g>
 <!-- Sidebar -->
 <g id="node9" class="node" pointer-events="visible" data-name="Sidebar">
 
-<polygon fill="none" stroke="black" points="420.81,-252 362.28,-252 362.28,-216 420.81,-216 420.81,-252" style=""/>
-<text text-anchor="middle" x="391.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Sidebar</text>
+<polygon fill="none" stroke="black" points="420.81,-252 362.28,-252 362.28,-216 420.81,-216 420.81,-252"/>
+<text text-anchor="middle" x="391.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Sidebar</text>
 </g>
 <!-- Sidebar&#45;&gt;Tokens &amp; Base -->
-<g id="edge13" class="edge" data-name="Sidebar-&gt;Tokens &amp; Base">
+<g id="edge13" class="edge" data-name="Sidebar-&gt;Fonts, Tokens, Base" data-comment="Sidebar-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M383.94,-215.63C377.06,-197.46 369.07,-168.26 376.54,-144 387.94,-107.01 393.73,-94.04 425.54,-72 471.44,-40.2 534.29,-27.4 580.72,-22.29" style=""/>
-<polygon fill="black" stroke="black" points="581.04,-25.77 590.64,-21.29 580.35,-18.81 581.04,-25.77" style=""/>
+<path fill="none" stroke="black" d="M383.94,-215.63C377.06,-197.46 369.07,-168.26 376.54,-144 387.94,-107.01 393.73,-94.04 425.54,-72 467.22,-43.13 522.88,-29.91 567.52,-23.9"/>
+<polygon fill="black" stroke="black" points="567.92,-27.38 577.41,-22.67 567.06,-20.43 567.92,-27.38"/>
 </g>
 <!-- Sidebar&#45;&gt;Button -->
 <g id="edge14" class="edge" data-name="Sidebar-&gt;Button">
 
-<path fill="none" stroke="black" d="M396.74,-215.7C398.97,-208.24 401.65,-199.32 404.16,-190.97" style=""/>
-<polygon fill="black" stroke="black" points="407.46,-192.14 406.98,-181.55 400.75,-190.13 407.46,-192.14" style=""/>
+<path fill="none" stroke="black" d="M396.74,-215.7C398.97,-208.24 401.65,-199.32 404.16,-190.97"/>
+<polygon fill="black" stroke="black" points="407.46,-192.14 406.98,-181.55 400.75,-190.13 407.46,-192.14"/>
 </g>
 <!-- Navbar -->
 <g id="node10" class="node" pointer-events="visible" data-name="Navbar">
 
-<polygon fill="none" stroke="black" points="496.25,-252 438.84,-252 438.84,-216 496.25,-216 496.25,-252" style=""/>
-<text text-anchor="middle" x="467.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Navbar</text>
+<polygon fill="none" stroke="black" points="496.25,-252 438.84,-252 438.84,-216 496.25,-216 496.25,-252"/>
+<text text-anchor="middle" x="467.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Navbar</text>
 </g>
 <!-- Navbar&#45;&gt;Tokens &amp; Base -->
-<g id="edge15" class="edge" data-name="Navbar-&gt;Tokens &amp; Base">
+<g id="edge15" class="edge" data-name="Navbar-&gt;Fonts, Tokens, Base" data-comment="Navbar-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M469.07,-215.68C472.79,-183.45 485.03,-113.78 523.54,-72 538.93,-55.32 560.51,-43.59 581.14,-35.49" style=""/>
-<polygon fill="black" stroke="black" points="582.2,-38.83 590.38,-32.1 579.79,-32.26 582.2,-38.83" style=""/>
+<path fill="none" stroke="black" d="M469.07,-215.68C472.79,-183.45 485.03,-113.78 523.54,-72 535.82,-58.69 552.04,-48.53 568.58,-40.86"/>
+<polygon fill="black" stroke="black" points="569.71,-44.18 577.49,-36.99 566.92,-37.76 569.71,-44.18"/>
 </g>
 <!-- Navbar&#45;&gt;Button -->
 <g id="edge16" class="edge" data-name="Navbar-&gt;Button">
 
-<path fill="none" stroke="black" d="M453.95,-215.7C447.62,-207.64 439.96,-197.89 432.96,-188.98" style=""/>
-<polygon fill="black" stroke="black" points="435.85,-187 426.92,-181.29 430.35,-191.32 435.85,-187" style=""/>
+<path fill="none" stroke="black" d="M453.95,-215.7C447.62,-207.64 439.96,-197.89 432.96,-188.98"/>
+<polygon fill="black" stroke="black" points="435.85,-187 426.92,-181.29 430.35,-191.32 435.85,-187"/>
 </g>
 <!-- Pagination -->
 <g id="node11" class="node" pointer-events="visible" data-name="Pagination">
 
-<polygon fill="none" stroke="black" points="590.43,-252 514.66,-252 514.66,-216 590.43,-216 590.43,-252" style=""/>
-<text text-anchor="middle" x="552.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Pagination</text>
+<polygon fill="none" stroke="black" points="590.43,-252 514.66,-252 514.66,-216 590.43,-216 590.43,-252"/>
+<text text-anchor="middle" x="552.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Pagination</text>
 </g>
 <!-- Pagination&#45;&gt;Tokens &amp; Base -->
-<g id="edge19" class="edge" data-name="Pagination-&gt;Tokens &amp; Base">
+<g id="edge19" class="edge" data-name="Pagination-&gt;Fonts, Tokens, Base" data-comment="Pagination-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M540.66,-215.72C534.53,-205.76 527.7,-192.73 524.54,-180 512.66,-132.08 518.75,-109.77 550.54,-72 560.95,-59.64 575,-49.57 589.03,-41.65" style=""/>
-<polygon fill="black" stroke="black" points="590.66,-44.75 597.86,-36.97 587.38,-38.56 590.66,-44.75" style=""/>
+<path fill="none" stroke="black" d="M540.66,-215.72C534.53,-205.76 527.7,-192.73 524.54,-180 512.66,-132.08 518.75,-109.77 550.54,-72 560.95,-59.64 575,-49.57 589.03,-41.65"/>
+<polygon fill="black" stroke="black" points="590.66,-44.75 597.86,-36.97 587.38,-38.56 590.66,-44.75"/>
 </g>
 <!-- Pagination&#45;&gt;Button -->
 <g id="edge17" class="edge" data-name="Pagination-&gt;Button">
 
-<path fill="none" stroke="black" d="M517.58,-215.52C497.07,-205.26 471.16,-192.31 450.2,-181.83" style=""/>
-<polygon fill="black" stroke="black" points="451.92,-178.77 441.41,-177.43 448.79,-185.03 451.92,-178.77" style=""/>
+<path fill="none" stroke="black" d="M517.58,-215.52C497.07,-205.26 471.16,-192.31 450.2,-181.83"/>
+<polygon fill="black" stroke="black" points="451.92,-178.77 441.41,-177.43 448.79,-185.03 451.92,-178.77"/>
 </g>
 <!-- Form -->
 <g id="node12" class="node" pointer-events="visible" data-name="Form">
 
-<polygon fill="none" stroke="black" points="587.54,-180 533.54,-180 533.54,-144 587.54,-144 587.54,-180" style=""/>
-<text text-anchor="middle" x="560.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Form</text>
+<polygon fill="none" stroke="black" points="587.54,-180 533.54,-180 533.54,-144 587.54,-144 587.54,-180"/>
+<text text-anchor="middle" x="560.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Form</text>
 </g>
 <!-- Pagination&#45;&gt;Form -->
 <g id="edge18" class="edge" data-name="Pagination-&gt;Form">
 
-<path fill="none" stroke="black" d="M554.52,-215.7C555.36,-208.41 556.35,-199.73 557.28,-191.54" style=""/>
-<polygon fill="black" stroke="black" points="560.76,-191.94 558.42,-181.61 553.81,-191.15 560.76,-191.94" style=""/>
+<path fill="none" stroke="black" d="M554.52,-215.7C555.36,-208.41 556.35,-199.73 557.28,-191.54"/>
+<polygon fill="black" stroke="black" points="560.76,-191.94 558.42,-181.61 553.81,-191.15 560.76,-191.94"/>
 </g>
 <!-- Form&#45;&gt;Tokens &amp; Base -->
-<g id="edge25" class="edge" data-name="Form-&gt;Tokens &amp; Base">
+<g id="edge25" class="edge" data-name="Form-&gt;Fonts, Tokens, Base" data-comment="Form-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M556.43,-143.71C552.91,-124.82 550.16,-94.29 562.54,-72 569.24,-59.95 579.96,-50.18 591.44,-42.46" style=""/>
-<polygon fill="black" stroke="black" points="593.22,-45.48 599.9,-37.26 589.55,-39.52 593.22,-45.48" style=""/>
+<path fill="none" stroke="black" d="M556.43,-143.71C552.91,-124.82 550.16,-94.29 562.54,-72 569.24,-59.95 579.96,-50.18 591.44,-42.46"/>
+<polygon fill="black" stroke="black" points="593.22,-45.48 599.9,-37.26 589.55,-39.52 593.22,-45.48"/>
 </g>
 <!-- Avatar -->
 <g id="node13" class="node" pointer-events="visible" data-name="Avatar">
 
-<polygon fill="none" stroke="black" points="625.63,-108 571.46,-108 571.46,-72 625.63,-72 625.63,-108" style=""/>
-<text text-anchor="middle" x="598.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Avatar</text>
+<polygon fill="none" stroke="black" points="625.63,-108 571.46,-108 571.46,-72 625.63,-72 625.63,-108"/>
+<text text-anchor="middle" x="598.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Avatar</text>
 </g>
 <!-- Avatar&#45;&gt;Tokens &amp; Base -->
-<g id="edge20" class="edge" data-name="Avatar-&gt;Tokens &amp; Base">
+<g id="edge20" class="edge" data-name="Avatar-&gt;Fonts, Tokens, Base" data-comment="Avatar-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M609.67,-71.7C614.74,-63.81 620.85,-54.3 626.48,-45.55" style=""/>
-<polygon fill="black" stroke="black" points="629.27,-47.68 631.73,-37.38 623.38,-43.9 629.27,-47.68" style=""/>
+<path fill="none" stroke="black" d="M609.67,-71.7C614.74,-63.81 620.85,-54.3 626.48,-45.55"/>
+<polygon fill="black" stroke="black" points="629.27,-47.68 631.73,-37.38 623.38,-43.9 629.27,-47.68"/>
 </g>
 <!-- Breadcrumbs -->
 <g id="node14" class="node" pointer-events="visible" data-name="Breadcrumbs">
 
-<polygon fill="none" stroke="black" points="733.69,-108 643.4,-108 643.4,-72 733.69,-72 733.69,-108" style=""/>
-<text text-anchor="middle" x="688.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Breadcrumbs</text>
+<polygon fill="none" stroke="black" points="733.69,-108 643.4,-108 643.4,-72 733.69,-72 733.69,-108"/>
+<text text-anchor="middle" x="688.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Breadcrumbs</text>
 </g>
 <!-- Breadcrumbs&#45;&gt;Tokens &amp; Base -->
-<g id="edge21" class="edge" data-name="Breadcrumbs-&gt;Tokens &amp; Base">
+<g id="edge21" class="edge" data-name="Breadcrumbs-&gt;Fonts, Tokens, Base" data-comment="Breadcrumbs-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M677.42,-71.7C672.35,-63.81 666.24,-54.3 660.61,-45.55" style=""/>
-<polygon fill="black" stroke="black" points="663.71,-43.9 655.36,-37.38 657.82,-47.68 663.71,-43.9" style=""/>
+<path fill="none" stroke="black" d="M677.42,-71.7C672.35,-63.81 666.24,-54.3 660.61,-45.55"/>
+<polygon fill="black" stroke="black" points="663.71,-43.9 655.36,-37.38 657.82,-47.68 663.71,-43.9"/>
 </g>
 <!-- Card -->
 <g id="node15" class="node" pointer-events="visible" data-name="Card">
 
-<polygon fill="none" stroke="black" points="805.54,-108 751.54,-108 751.54,-72 805.54,-72 805.54,-108" style=""/>
-<text text-anchor="middle" x="778.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Card</text>
+<polygon fill="none" stroke="black" points="805.54,-108 751.54,-108 751.54,-72 805.54,-72 805.54,-108"/>
+<text text-anchor="middle" x="778.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Card</text>
 </g>
 <!-- Card&#45;&gt;Tokens &amp; Base -->
-<g id="edge22" class="edge" data-name="Card-&gt;Tokens &amp; Base">
+<g id="edge22" class="edge" data-name="Card-&gt;Fonts, Tokens, Base" data-comment="Card-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M751.23,-74.83C732.82,-65.29 708.14,-52.5 687.06,-41.56" style=""/>
-<polygon fill="black" stroke="black" points="688.87,-38.56 678.38,-37.06 685.65,-44.78 688.87,-38.56" style=""/>
+<path fill="none" stroke="black" d="M751.23,-74.83C732.82,-65.29 708.14,-52.5 687.06,-41.56"/>
+<polygon fill="black" stroke="black" points="688.87,-38.56 678.38,-37.06 685.65,-44.78 688.87,-38.56"/>
 </g>
 <!-- Confirm Dialog -->
 <g id="node16" class="node" pointer-events="visible" data-name="Confirm Dialog">
 
-<polygon fill="none" stroke="black" points="929.09,-108 824,-108 824,-72 929.09,-72 929.09,-108" style=""/>
-<text text-anchor="middle" x="876.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Confirm Dialog</text>
+<polygon fill="none" stroke="black" points="929.09,-108 824,-108 824,-72 929.09,-72 929.09,-108"/>
+<text text-anchor="middle" x="876.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Confirm Dialog</text>
 </g>
 <!-- Confirm Dialog&#45;&gt;Tokens &amp; Base -->
-<g id="edge23" class="edge" data-name="Confirm Dialog-&gt;Tokens &amp; Base">
+<g id="edge23" class="edge" data-name="Confirm Dialog-&gt;Fonts, Tokens, Base" data-comment="Confirm Dialog-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M823.67,-73.12C788.6,-62.58 742.43,-48.71 705.61,-37.65" style=""/>
-<polygon fill="black" stroke="black" points="707.04,-34.42 696.45,-34.9 705.02,-41.12 707.04,-34.42" style=""/>
+<path fill="none" stroke="black" d="M823.67,-73.12C790.7,-63.21 747.91,-50.36 712.31,-39.66"/>
+<polygon fill="black" stroke="black" points="713.55,-36.38 702.97,-36.85 711.54,-43.08 713.55,-36.38"/>
 </g>
 <!-- Divider -->
 <g id="node17" class="node" pointer-events="visible" data-name="Divider">
 
-<polygon fill="none" stroke="black" points="1005.81,-108 947.28,-108 947.28,-72 1005.81,-72 1005.81,-108" style=""/>
-<text text-anchor="middle" x="976.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Divider</text>
+<polygon fill="none" stroke="black" points="1005.81,-108 947.28,-108 947.28,-72 1005.81,-72 1005.81,-108"/>
+<text text-anchor="middle" x="976.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Divider</text>
 </g>
 <!-- Divider&#45;&gt;Tokens &amp; Base -->
-<g id="edge24" class="edge" data-name="Divider-&gt;Tokens &amp; Base">
+<g id="edge24" class="edge" data-name="Divider-&gt;Fonts, Tokens, Base" data-comment="Divider-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M946.94,-74.94C944.13,-73.85 941.31,-72.85 938.54,-72 860.42,-47.9 767.07,-33.42 706.61,-25.83" style=""/>
-<polygon fill="black" stroke="black" points="707.2,-22.37 696.84,-24.63 706.34,-29.32 707.2,-22.37" style=""/>
+<path fill="none" stroke="black" d="M946.94,-74.94C944.13,-73.85 941.31,-72.85 938.54,-72 865.91,-49.59 780.11,-35.5 719.82,-27.53"/>
+<polygon fill="black" stroke="black" points="720.36,-24.07 709.99,-26.26 719.46,-31.01 720.36,-24.07"/>
 </g>
 <!-- Modal -->
 <g id="node18" class="node" pointer-events="visible" data-name="Modal">
 
-<polygon fill="none" stroke="black" points="1077.54,-108 1023.54,-108 1023.54,-72 1077.54,-72 1077.54,-108" style=""/>
-<text text-anchor="middle" x="1050.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Modal</text>
+<polygon fill="none" stroke="black" points="1077.54,-108 1023.54,-108 1023.54,-72 1077.54,-72 1077.54,-108"/>
+<text text-anchor="middle" x="1050.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Modal</text>
 </g>
 <!-- Modal&#45;&gt;Tokens &amp; Base -->
-<g id="edge27" class="edge" data-name="Modal-&gt;Tokens &amp; Base">
+<g id="edge27" class="edge" data-name="Modal-&gt;Fonts, Tokens, Base" data-comment="Modal-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1023.36,-75.13C1020.43,-73.95 1017.46,-72.87 1014.54,-72 909.18,-40.38 781.17,-27.41 706.38,-22.25" style=""/>
-<polygon fill="black" stroke="black" points="707.01,-18.78 696.8,-21.61 706.55,-25.77 707.01,-18.78" style=""/>
+<path fill="none" stroke="black" d="M1023.36,-75.13C1020.43,-73.95 1017.46,-72.87 1014.54,-72 915.26,-42.21 795.86,-28.97 719.84,-23.22"/>
+<polygon fill="black" stroke="black" points="720.22,-19.74 709.99,-22.5 719.71,-26.72 720.22,-19.74"/>
 </g>
 <!-- Side Panel -->
 <g id="node19" class="node" pointer-events="visible" data-name="Side Panel">
 
-<polygon fill="none" stroke="black" points="1171.54,-108 1095.55,-108 1095.55,-72 1171.54,-72 1171.54,-108" style=""/>
-<text text-anchor="middle" x="1133.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Side Panel</text>
+<polygon fill="none" stroke="black" points="1171.54,-108 1095.55,-108 1095.55,-72 1171.54,-72 1171.54,-108"/>
+<text text-anchor="middle" x="1133.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Side Panel</text>
 </g>
 <!-- Side Panel&#45;&gt;Tokens &amp; Base -->
-<g id="edge28" class="edge" data-name="Side Panel-&gt;Tokens &amp; Base">
+<g id="edge28" class="edge" data-name="Side Panel-&gt;Fonts, Tokens, Base" data-comment="Side Panel-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1095.29,-74.36C1092.35,-73.48 1089.42,-72.68 1086.54,-72 953.43,-40.4 793.11,-27.18 706.5,-22.01" style=""/>
-<polygon fill="black" stroke="black" points="706.73,-18.52 696.55,-21.44 706.33,-25.51 706.73,-18.52" style=""/>
+<path fill="none" stroke="black" d="M1095.29,-74.36C1092.35,-73.48 1089.42,-72.68 1086.54,-72 960.02,-41.96 808.91,-28.53 719.89,-22.84"/>
+<polygon fill="black" stroke="black" points="720.25,-19.36 710.06,-22.23 719.82,-26.34 720.25,-19.36"/>
 </g>
 <!-- Spinner -->
 <g id="node20" class="node" pointer-events="visible" data-name="Spinner">
 
-<polygon fill="none" stroke="black" points="1249.1,-108 1189.99,-108 1189.99,-72 1249.1,-72 1249.1,-108" style=""/>
-<text text-anchor="middle" x="1219.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Spinner</text>
+<polygon fill="none" stroke="black" points="1249.1,-108 1189.99,-108 1189.99,-72 1249.1,-72 1249.1,-108"/>
+<text text-anchor="middle" x="1219.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Spinner</text>
 </g>
 <!-- Spinner&#45;&gt;Tokens &amp; Base -->
-<g id="edge29" class="edge" data-name="Spinner-&gt;Tokens &amp; Base">
+<g id="edge29" class="edge" data-name="Spinner-&gt;Fonts, Tokens, Base" data-comment="Spinner-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1189.64,-74.86C1186.61,-73.76 1183.55,-72.78 1180.54,-72 1013.16,-28.42 807.89,-20.13 706.45,-18.9" style=""/>
-<polygon fill="black" stroke="black" points="706.74,-15.4 696.71,-18.8 706.67,-22.4 706.74,-15.4" style=""/>
+<path fill="none" stroke="black" d="M1189.64,-74.86C1186.61,-73.76 1183.55,-72.78 1180.54,-72 1020.2,-30.25 825.09,-20.89 719.79,-19.09"/>
+<polygon fill="black" stroke="black" points="719.9,-15.6 709.84,-18.94 719.79,-22.59 719.9,-15.6"/>
 </g>
 <!-- Switch -->
 <g id="node21" class="node" pointer-events="visible" data-name="Switch">
 
-<polygon fill="none" stroke="black" points="1321.93,-108 1267.16,-108 1267.16,-72 1321.93,-72 1321.93,-108" style=""/>
-<text text-anchor="middle" x="1294.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Switch</text>
+<polygon fill="none" stroke="black" points="1321.93,-108 1267.16,-108 1267.16,-72 1321.93,-72 1321.93,-108"/>
+<text text-anchor="middle" x="1294.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Switch</text>
 </g>
 <!-- Switch&#45;&gt;Tokens &amp; Base -->
-<g id="edge30" class="edge" data-name="Switch-&gt;Tokens &amp; Base">
+<g id="edge30" class="edge" data-name="Switch-&gt;Fonts, Tokens, Base" data-comment="Switch-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1267.01,-74.81C1264.2,-73.72 1261.35,-72.76 1258.54,-72 1155.75,-44.26 842,-27.65 706.72,-21.61" style=""/>
-<polygon fill="black" stroke="black" points="707.01,-18.12 696.87,-21.17 706.7,-25.11 707.01,-18.12" style=""/>
+<path fill="none" stroke="black" d="M1267.01,-74.81C1264.2,-73.72 1261.35,-72.76 1258.54,-72 1158.88,-45.1 860.91,-28.67 719.56,-22.19"/>
+<polygon fill="black" stroke="black" points="720.09,-18.71 709.94,-21.75 719.77,-25.7 720.09,-18.71"/>
 </g>
 <!-- Tab -->
 <g id="node22" class="node" pointer-events="visible" data-name="Tab">
 
-<polygon fill="none" stroke="black" points="1393.54,-108 1339.54,-108 1339.54,-72 1393.54,-72 1393.54,-108" style=""/>
-<text text-anchor="middle" x="1366.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Tab</text>
+<polygon fill="none" stroke="black" points="1393.54,-108 1339.54,-108 1339.54,-72 1393.54,-72 1393.54,-108"/>
+<text text-anchor="middle" x="1366.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tab</text>
 </g>
 <!-- Tab&#45;&gt;Tokens &amp; Base -->
-<g id="edge31" class="edge" data-name="Tab-&gt;Tokens &amp; Base">
+<g id="edge31" class="edge" data-name="Tab-&gt;Fonts, Tokens, Base" data-comment="Tab-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1339.42,-74.94C1336.48,-73.79 1333.48,-72.78 1330.54,-72 1213.74,-41.04 853.43,-25.94 706.7,-20.95" style=""/>
-<polygon fill="black" stroke="black" points="706.88,-17.45 696.77,-20.61 706.65,-24.45 706.88,-17.45" style=""/>
+<path fill="none" stroke="black" d="M1339.42,-74.94C1336.48,-73.79 1333.48,-72.78 1330.54,-72 1217.03,-41.91 873.54,-26.8 719.6,-21.39"/>
+<polygon fill="black" stroke="black" points="720.03,-17.9 709.92,-21.06 719.79,-24.9 720.03,-17.9"/>
 </g>
 <!-- Table -->
 <g id="node23" class="node" pointer-events="visible" data-name="Table">
 
-<polygon fill="none" stroke="black" points="1465.54,-108 1411.54,-108 1411.54,-72 1465.54,-72 1465.54,-108" style=""/>
-<text text-anchor="middle" x="1438.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Table</text>
+<polygon fill="none" stroke="black" points="1465.54,-108 1411.54,-108 1411.54,-72 1465.54,-72 1465.54,-108"/>
+<text text-anchor="middle" x="1438.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Table</text>
 </g>
 <!-- Table&#45;&gt;Tokens &amp; Base -->
-<g id="edge32" class="edge" data-name="Table-&gt;Tokens &amp; Base">
+<g id="edge32" class="edge" data-name="Table-&gt;Fonts, Tokens, Base" data-comment="Table-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1411.42,-74.91C1408.48,-73.77 1405.49,-72.77 1402.54,-72 1271.63,-37.81 864.15,-24.4 706.61,-20.41" style=""/>
-<polygon fill="black" stroke="black" points="706.86,-16.91 696.77,-20.16 706.68,-23.91 706.86,-16.91" style=""/>
+<path fill="none" stroke="black" d="M1411.42,-74.91C1408.48,-73.77 1405.49,-72.77 1402.54,-72 1275.03,-38.7 885.17,-25.11 719.41,-20.74"/>
+<polygon fill="black" stroke="black" points="719.94,-17.25 709.86,-20.49 719.76,-24.25 719.94,-17.25"/>
 </g>
 <!-- Text Pair -->
 <g id="node24" class="node" pointer-events="visible" data-name="Text Pair">
 
-<polygon fill="none" stroke="black" points="1551.25,-108 1483.84,-108 1483.84,-72 1551.25,-72 1551.25,-108" style=""/>
-<text text-anchor="middle" x="1517.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Text Pair</text>
+<polygon fill="none" stroke="black" points="1551.25,-108 1483.84,-108 1483.84,-72 1551.25,-72 1551.25,-108"/>
+<text text-anchor="middle" x="1517.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Text Pair</text>
 </g>
 <!-- Text Pair&#45;&gt;Tokens &amp; Base -->
-<g id="edge33" class="edge" data-name="Text Pair-&gt;Tokens &amp; Base">
+<g id="edge33" class="edge" data-name="Text Pair-&gt;Fonts, Tokens, Base" data-comment="Text Pair-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1483.58,-74.46C1480.56,-73.51 1477.52,-72.67 1474.54,-72 1328.35,-39.29 874.2,-24.81 706.55,-20.48" style=""/>
-<polygon fill="black" stroke="black" points="706.82,-16.98 696.73,-20.23 706.64,-23.98 706.82,-16.98" style=""/>
+<path fill="none" stroke="black" d="M1483.58,-74.46C1480.56,-73.51 1477.52,-72.67 1474.54,-72 1332.01,-40.11 896.76,-25.54 719.68,-20.82"/>
+<polygon fill="black" stroke="black" points="720,-17.33 709.91,-20.56 719.82,-24.33 720,-17.33"/>
 </g>
 <!-- Tooltip -->
 <g id="node25" class="node" pointer-events="visible" data-name="Tooltip">
 
-<polygon fill="none" stroke="black" points="1626.27,-108 1568.82,-108 1568.82,-72 1626.27,-72 1626.27,-108" style=""/>
-<text text-anchor="middle" x="1597.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00" style="">Tooltip</text>
+<polygon fill="none" stroke="black" points="1626.27,-108 1568.82,-108 1568.82,-72 1626.27,-72 1626.27,-108"/>
+<text text-anchor="middle" x="1597.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tooltip</text>
 </g>
 <!-- Tooltip&#45;&gt;Tokens &amp; Base -->
-<g id="edge34" class="edge" data-name="Tooltip-&gt;Tokens &amp; Base">
+<g id="edge34" class="edge" data-name="Tooltip-&gt;Fonts, Tokens, Base" data-comment="Tooltip-&gt;Tokens &amp; Base">
 
-<path fill="none" stroke="black" d="M1568.42,-74.43C1565.8,-73.48 1563.15,-72.65 1560.54,-72 1398.25,-31.56 886.22,-21.81 706.58,-19.6" style=""/>
-<polygon fill="black" stroke="black" points="706.79,-16.11 696.75,-19.49 706.71,-23.11 706.79,-16.11" style=""/>
+<path fill="none" stroke="black" d="M1568.42,-74.43C1565.8,-73.48 1563.15,-72.65 1560.54,-72 1402.08,-32.51 910.21,-22.29 719.85,-19.77"/>
+<polygon fill="black" stroke="black" points="720.13,-16.28 710.09,-19.65 720.04,-23.28 720.13,-16.28"/>
 </g>
 </g>
 </svg>

--- a/tools/generate-graph.dot
+++ b/tools/generate-graph.dot
@@ -3,49 +3,49 @@ digraph dependencies {
   node [fontname = "Helvetica,Arial,sans-serif";];
   edge [fontname = "Helvetica,Arial,sans-serif";];
   node [shape = box;];
-  "Tokens & Base";
+  "Fonts, Tokens, Base";
 
-  "Accordion" -> "Tokens & Base";
+  "Accordion" -> "Fonts, Tokens, Base";
   "Accordion" -> "Icon";
 
-  "Alert" -> "Tokens & Base";
+  "Alert" -> "Fonts, Tokens, Base";
   "Alert" -> "Icon";
 
-  "Badge" -> "Tokens & Base";
+  "Badge" -> "Fonts, Tokens, Base";
   "Badge" -> "Icon";
 
-  "Button" -> "Tokens & Base";
+  "Button" -> "Fonts, Tokens, Base";
   "Button" -> "Icon";
 
-  "Tag" -> "Tokens & Base";
+  "Tag" -> "Fonts, Tokens, Base";
   "Tag" -> "Icon";
 
-  "Button Group" -> "Tokens & Base";
+  "Button Group" -> "Fonts, Tokens, Base";
   "Button Group" -> "Button";
 
-  "Sidebar" -> "Tokens & Base";
+  "Sidebar" -> "Fonts, Tokens, Base";
   "Sidebar" -> "Button";
 
-  "Navbar" -> "Tokens & Base";
+  "Navbar" -> "Fonts, Tokens, Base";
   "Navbar" -> "Button";
 
   "Pagination" -> "Button";
   "Pagination" -> "Form";
-  "Pagination" -> "Tokens & Base";
+  "Pagination" -> "Fonts, Tokens, Base";
 
-  "Avatar" -> "Tokens & Base";
-  "Breadcrumbs" -> "Tokens & Base";
-  "Card" -> "Tokens & Base";
-  "Confirm Dialog" -> "Tokens & Base";
-  "Divider" -> "Tokens & Base";
-  "Form" -> "Tokens & Base";
-  "Icon" -> "Tokens & Base";
-  "Modal" -> "Tokens & Base";
-  "Side Panel" -> "Tokens & Base";
-  "Spinner" -> "Tokens & Base";
-  "Switch" -> "Tokens & Base";
-  "Tab" -> "Tokens & Base";
-  "Table" -> "Tokens & Base";
-  "Text Pair" -> "Tokens & Base";
-  "Tooltip" -> "Tokens & Base";
+  "Avatar" -> "Fonts, Tokens, Base";
+  "Breadcrumbs" -> "Fonts, Tokens, Base";
+  "Card" -> "Fonts, Tokens, Base";
+  "Confirm Dialog" -> "Fonts, Tokens, Base";
+  "Divider" -> "Fonts, Tokens, Base";
+  "Form" -> "Fonts, Tokens, Base";
+  "Icon" -> "Fonts, Tokens, Base";
+  "Modal" -> "Fonts, Tokens, Base";
+  "Side Panel" -> "Fonts, Tokens, Base";
+  "Spinner" -> "Fonts, Tokens, Base";
+  "Switch" -> "Fonts, Tokens, Base";
+  "Tab" -> "Fonts, Tokens, Base";
+  "Table" -> "Fonts, Tokens, Base";
+  "Text Pair" -> "Fonts, Tokens, Base";
+  "Tooltip" -> "Fonts, Tokens, Base";
 }

--- a/tools/templates/component/??name??(pascalCase).mdx
+++ b/tools/templates/component/??name??(pascalCase).mdx
@@ -20,6 +20,7 @@ Brief overview description of how to use ??name??(pascalCase) classes
 
 ```css
 /* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
 @import '@rolemodel/optics/dist/css/core/tokens';
 @import '@rolemodel/optics/dist/css/core/base';
 


### PR DESCRIPTION
## Why?

Moving the font imports to their own files allows for better organizing, overriding, customizing, and clearer documentation.

## What Changed

- [X] Move font imports out of icon and base tokens and into `core/fonts/text_fonts.css` and `core/fonts/icon_fonts.css`
- [X] Update selective imports documentation
- [X] Update file organization documentation
- [X] Update comments in documentation code examples to use the correct syntax
- [X] Update dependency notes and the graph to include the fonts

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- [X] Have you updated the dependency graph with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots

<img width="1033" alt="Screenshot 2025-02-10 at 9 55 16 PM" src="https://github.com/user-attachments/assets/0c4cf98b-3503-47ac-9480-648666e56c0d" />
<img width="1035" alt="Screenshot 2025-02-10 at 9 55 27 PM" src="https://github.com/user-attachments/assets/3f049cf2-8ffd-4c28-9e04-b4d291feccdb" />
<img width="1030" alt="Screenshot 2025-02-10 at 9 55 31 PM" src="https://github.com/user-attachments/assets/cbe46fff-e1f4-40d0-ab18-6cf8db3fc1b3" />
<img width="376" alt="Screenshot 2025-02-10 at 9 56 08 PM" src="https://github.com/user-attachments/assets/4834fec5-e487-4407-bdbe-4e3619dbc5e9" />
<img width="1111" alt="Screenshot 2025-02-10 at 11 06 13 PM" src="https://github.com/user-attachments/assets/5e6592db-c9d4-45f6-86c0-39937fbed901" />
<img width="1040" alt="Screenshot 2025-02-10 at 11 06 25 PM" src="https://github.com/user-attachments/assets/07a3aff7-e9b5-42ec-9cd1-0f4b0023782c" />
