### PR TITLE
[OP-195] Icon improvements

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,4 +1,5 @@
 @import '../src/optics';
+@import '../src/addons/fonts/material_symbols_outlined_variable';
 
 @import '../src/recipes/domains-sidebar';
 @import '../src/recipes/16six-sidebar';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "packageManager": "yarn@4.2.2",
   "description": "Optics is a css package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/css/optics.css",

--- a/src/addons/fonts/material_symbols_outlined_variable.css
+++ b/src/addons/fonts/material_symbols_outlined_variable.css
@@ -1,0 +1,10 @@
+/*
+  See all icons at: https://fonts.google.com/icons?icon.set=Material+Symbols
+  Material Symbols supports:
+  fill set through: font-variation-settings: 'FILL' {0|1}
+  font weight set through: font-variation-settings: 'wght' {100..700}
+  emphasis set through: font-variation-settings: 'GRAD' {-20|0|200}
+  optical sizing set through: font-variation-settings: 'opsz' {20|40|48}
+*/
+
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block';

--- a/src/addons/fonts/material_symbols_outlined_variable.css
+++ b/src/addons/fonts/material_symbols_outlined_variable.css
@@ -1,10 +1,10 @@
 /*
   See all icons at: https://fonts.google.com/icons?icon.set=Material+Symbols
   Material Symbols supports:
-  fill set through: font-variation-settings: 'FILL' {0|1}
-  font weight set through: font-variation-settings: 'wght' {100..700}
-  emphasis set through: font-variation-settings: 'GRAD' {-20|0|200}
   optical sizing set through: font-variation-settings: 'opsz' {20|40|48}
+  font weight set through: font-variation-settings: 'wght' {100..700}
+  fill set through: font-variation-settings: 'FILL' {0|1}
+  emphasis set through: font-variation-settings: 'GRAD' {-50|0|200}
 */
 
 @import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block';

--- a/src/components/accordion.css
+++ b/src/components/accordion.css
@@ -28,9 +28,9 @@
     }
 
     .accordion__marker {
-      --op-mso-optical-sizing: 48;
+      --__op-icon-font-size: var(--_op-icon-font-size-x-large);
+      --__op-icon-optical-size: var(--_op-icon-optical-size-x-large);
 
-      font-size: var(--op-font-x-large);
       justify-self: flex-end;
       transition: var(--op-transition-accordion);
       user-select: none;

--- a/src/components/alert.css
+++ b/src/components/alert.css
@@ -8,10 +8,10 @@
   /* Elements */
 
   .alert__icon {
-    --op-mso-optical-sizing: 40; /* .icon--large styling */
-    --op-mso-weight: var(--op-font-weight-bold); /* .icon--weight-bold styling */
+    --__op-icon-font-size: var(--_op-icon-font-size-large);
+    --__op-icon-optical-size: var(--_op-icon-optical-size-large);
+    --__op-icon-weight: var(--_op-icon-weight-bold);
 
-    font-size: var(--op-font-large); /* .icon--large styling */
     line-height: var(--op-line-height-dense);
   }
 

--- a/src/components/icon.css
+++ b/src/components/icon.css
@@ -1,6 +1,4 @@
-/* Class provided by the Google Fonts CDN */
-.material-symbols-outlined,
-.custom-icons {
+.icon {
   /* Public API (customizable component options) */
 
   /* Weight */
@@ -39,19 +37,9 @@
   width: var(--__op-icon-font-size);
   height: var(--__op-icon-font-size);
   font-size: var(--__op-icon-font-size);
-  font-variation-settings:
-    'FILL' var(--__op-icon-fill),
-    'wght' var(--__op-icon-weight),
-    'GRAD' var(--__op-icon-emphasis),
-    'opsz' var(--__op-icon-optical-size);
+  font-weight: var(--__op-icon-weight);
   line-height: var(--op-line-height-densest);
   vertical-align: middle;
-
-  /* Primarily for custom icons */
-  svg {
-    width: 100%;
-    height: 100%;
-  }
 
   /* Fill Modifiers */
   &.icon--outlined {
@@ -111,5 +99,23 @@
   &.icon--x-large {
     --__op-icon-font-size: var(--_op-icon-font-size-x-large);
     --__op-icon-optical-size: var(--_op-icon-optical-size-x-large);
+  }
+}
+
+/* Material Icons class provided by the Google Fonts CDN */
+.material-symbols-outlined {
+  font-variation-settings:
+    'FILL' var(--__op-icon-fill),
+    'wght' var(--__op-icon-weight),
+    'GRAD' var(--__op-icon-emphasis),
+    'opsz' var(--__op-icon-optical-size);
+  font-weight: unset;
+}
+
+/* Custom SVG Icons app specific */
+.custom-icons {
+  svg {
+    width: 100%;
+    height: 100%;
   }
 }

--- a/src/components/icon.css
+++ b/src/components/icon.css
@@ -35,6 +35,9 @@
   --__op-icon-font-size: var(--_op-icon-font-size-medium);
   --__op-icon-optical-size: var(--_op-icon-optical-size-medium);
 
+  display: inline-block;
+  width: var(--__op-icon-font-size);
+  height: var(--__op-icon-font-size);
   font-size: var(--__op-icon-font-size);
   font-variation-settings:
     'FILL' var(--__op-icon-fill),
@@ -43,6 +46,12 @@
     'opsz' var(--__op-icon-optical-size);
   line-height: var(--op-line-height-densest);
   vertical-align: middle;
+
+  /* Primarily for custom icons */
+  svg {
+    width: 100%;
+    height: 100%;
+  }
 
   /* Fill Modifiers */
   &.icon--outlined {
@@ -102,16 +111,5 @@
   &.icon--x-large {
     --__op-icon-font-size: var(--_op-icon-font-size-x-large);
     --__op-icon-optical-size: var(--_op-icon-optical-size-x-large);
-  }
-}
-
-.custom-icons {
-  display: inline-block;
-  width: var(--__op-icon-font-size);
-  height: var(--__op-icon-font-size);
-
-  svg {
-    width: 100%;
-    height: 100%;
   }
 }

--- a/src/components/icon.css
+++ b/src/components/icon.css
@@ -1,105 +1,117 @@
+/* Class provided by the Google Fonts CDN */
 .material-symbols-outlined,
-.material-symbols {
-  --op-mso-fill: 0;
-  --op-mso-weight: var(--op-font-weight-normal);
-  --op-mso-grade: 0;
-  --op-mso-optical-sizing: 20;
+.custom-icons {
+  /* Public API (customizable component options) */
 
-  font-size: var(--op-font-medium);
+  /* Weight */
+  --_op-icon-weight-light: var(--op-font-weight-light);
+  --_op-icon-weight-normal: var(--op-font-weight-normal);
+  --_op-icon-weight-semi-bold: var(--op-font-weight-semi-bold);
+  --_op-icon-weight-bold: var(--op-font-weight-bold);
+
+  /* Fill */
+  --_op-icon-fill-outlined: 0;
+  --_op-icon-fill-filled: 1;
+
+  /* Emphasis */
+  --_op-icon-emphasis-low: -20;
+  --_op-icon-emphasis-normal: 0;
+  --_op-icon-emphasis-high: 200;
+
+  /* Size */
+  --_op-icon-font-size-small: var(--op-font-small);
+  --_op-icon-font-size-medium: var(--op-font-medium);
+  --_op-icon-font-size-large: var(--op-font-large);
+  --_op-icon-font-size-x-large: var(--op-font-2x-large);
+  --_op-icon-optical-size-small: 20;
+  --_op-icon-optical-size-medium: 20;
+  --_op-icon-optical-size-large: 40;
+  --_op-icon-optical-size-x-large: 48;
+
+  /* Private API (component option defaults) */
+  --__op-icon-weight: var(--_op-icon-weight-normal);
+  --__op-icon-fill: var(--_op-icon-fill-outlined);
+  --__op-icon-emphasis: var(--_op-icon-emphasis-normal);
+  --__op-icon-font-size: var(--_op-icon-font-size-medium);
+  --__op-icon-optical-size: var(--_op-icon-optical-size-medium);
+
+  font-size: var(--__op-icon-font-size);
   font-variation-settings:
-    'FILL' var(--op-mso-fill),
-    'wght' var(--op-mso-weight),
-    'GRAD' var(--op-mso-grade),
-    'opsz' var(--op-mso-optical-sizing);
+    'FILL' var(--__op-icon-fill),
+    'wght' var(--__op-icon-weight),
+    'GRAD' var(--__op-icon-emphasis),
+    'opsz' var(--__op-icon-optical-size);
   line-height: var(--op-line-height-densest);
   vertical-align: middle;
-}
 
-/* Fill */
-.icon--outlined {
-  --op-mso-fill: 0;
-}
+  /* Fill Modifiers */
+  &.icon--outlined {
+    --__op-icon-fill: var(--_op-icon-fill-outlined);
+  }
 
-.icon--filled {
-  --op-mso-fill: 1;
-}
+  &.icon--filled {
+    --__op-icon-fill: var(--_op-icon-fill-filled);
+  }
 
-/* Weight */
-.icon--weight-light {
-  --op-mso-weight: var(--op-font-weight-light);
-}
+  /* Weight Modifiers */
+  &.icon--weight-light {
+    --__op-icon-weight: var(--_op-icon-weight-light);
+  }
 
-.icon--weight-normal {
-  --op-mso-weight: var(--op-font-weight-normal);
-}
+  &.icon--weight-normal {
+    --__op-icon-weight: var(--_op-icon-weight-normal);
+  }
 
-.icon--weight-semi-bold {
-  --op-mso-weight: var(--op-font-weight-semi-bold);
-}
+  &.icon--weight-semi-bold {
+    --__op-icon-weight: var(--_op-icon-weight-semi-bold);
+  }
 
-.icon--weight-bold {
-  --op-mso-weight: var(--op-font-weight-bold);
-}
+  &.icon--weight-bold {
+    --__op-icon-weight: var(--_op-icon-weight-bold);
+  }
 
-/* Emphasis */
-.icon--low-emphasis {
-  --op-mso-grade: -20;
-}
+  /* Emphasis */
+  &.icon--low-emphasis {
+    --__op-icon-emphasis: var(--_op-icon-emphasis-low);
+  }
 
-.icon--normal-emphasis {
-  --op-mso-grade: 0;
-}
+  &.icon--normal-emphasis {
+    --__op-icon-emphasis: var(--_op-icon-emphasis-normal);
+  }
 
-.icon--high-emphasis {
-  --op-mso-grade: 200;
-}
+  &.icon--high-emphasis {
+    --__op-icon-emphasis: var(--_op-icon-emphasis-high);
+  }
 
-/* Size */
-.icon--medium {
-  font-size: var(--op-font-medium);
+  /* Size Modifiers */
+  &.icon--small {
+    --__op-icon-font-size: var(--_op-icon-font-size-small);
+    --__op-icon-optical-size: var(--_op-icon-optical-size-small);
+  }
 
-  --op-mso-optical-sizing: 20;
-}
+  &.icon--medium {
+    --__op-icon-font-size: var(--_op-icon-font-size-medium);
+    --__op-icon-optical-size: var(--_op-icon-optical-size-medium);
+  }
 
-.icon--large {
-  font-size: var(--op-font-large);
+  &.icon--large {
+    --__op-icon-font-size: var(--_op-icon-font-size-large);
+    --__op-icon-optical-size: var(--_op-icon-optical-size-large);
+  }
 
-  --op-mso-optical-sizing: 40;
-}
-
-.icon--x-large {
-  font-size: var(--op-font-2x-large);
-
-  --op-mso-optical-sizing: 48;
+  &.icon--x-large {
+    --__op-icon-font-size: var(--_op-icon-font-size-x-large);
+    --__op-icon-optical-size: var(--_op-icon-optical-size-x-large);
+  }
 }
 
 .custom-icons {
   display: inline-block;
-  width: var(--op-font-2x-large);
-  height: var(--op-font-2x-large);
+  width: var(--__op-icon-font-size);
+  height: var(--__op-icon-font-size);
 
-  &.icon--medium {
-    font-size: var(--op-font-small);
-
-    --op-mso-optical-sizing: 20;
+  svg {
+    width: 100%;
+    height: 100%;
   }
-
-  &.icon--large {
-    width: var(--op-font-large);
-    height: var(--op-font-large);
-  }
-
-  &.icon--x-large {
-    width: var(--op-font-3x-large);
-    height: var(--op-font-3x-large);
-  }
-}
-
-.custom-icons svg {
-  width: 100%;
-  height: 100%;
-}
-
-.icon-link {
-  line-height: 0;
 }

--- a/src/components/sidebar.css
+++ b/src/components/sidebar.css
@@ -60,10 +60,9 @@
       justify-content: flex-start;
 
       .material-symbols-outlined {
-        --op-mso-optical-sizing: 40;
-        --op-mso-weight: var(--op-font-weight-bold);
-
-        font-size: var(--op-font-large);
+        --__op-icon-font-size: var(--_op-icon-font-size-large);
+        --__op-icon-optical-size: var(--_op-icon-optical-size-large);
+        --__op-icon-weight: var(--_op-icon-weight-bold);
       }
     }
 

--- a/src/core/fonts/icon_fonts.css
+++ b/src/core/fonts/icon_fonts.css
@@ -1,11 +1,8 @@
 /*
   See all icons at: https://fonts.google.com/icons?icon.set=Material+Symbols
-  Material Symbols supports:
-  fill set through: font-variation-settings: 'FILL' {0|1}
-  font weight set through: font-variation-settings: 'wght' {100..900}
-  emphasis set through: font-variation-settings: 'GRAD' {-20|0|200}
-  optical sizing set through: font-variation-settings: 'opsz' {20|40|48}
+  This import of Material Symbols supports:
+  font weight set through: font-variation-settings: 'wght' {100..700}
 */
 
 /* Material Symbols */
-@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block';
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@100..700&display=block';

--- a/src/core/fonts/index.css
+++ b/src/core/fonts/index.css
@@ -1,9 +1,6 @@
 /*
   Instead of hosting the font files locally which requires a compiler to handle them, we pull fonts
-  from Googles CDN. This does have downsides. For instance, the  font files are large so on first load,
-  there will be a flash of unstyled space where the text is. Changing the import to not use the variable
-  version of the font would fix this, but there is a tradeoff as we would lose the ability to choose fill,
-  weight, optical size, and ephasis. For more information on the variable font, see:
+  from Googles CDN. For more information on the variable font, see:
   https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
 */
 

--- a/src/core/fonts/index.css
+++ b/src/core/fonts/index.css
@@ -1,6 +1,9 @@
 /*
   Instead of hosting the font files locally which requires a compiler to handle them, we pull fonts
-  from Googles CDN. This does introduce a slight performance hit, but it's a tradeoff for simplicity.
+  from Googles CDN. This does have downsides. For instance, the  font files are large so on first load,
+  there will be a flash of unstyled space where the text is. Changing the import to not use the variable
+  version of the font would fix this, but there is a tradeoff as we would lose the ability to choose fill,
+  weight, optical size, and ephasis. For more information on the variable font, see:
   https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
 */
 

--- a/src/core/fonts/index.css
+++ b/src/core/fonts/index.css
@@ -1,6 +1,6 @@
 /*
   Instead of hosting the font files locally which requires a compiler to handle them, we pull fonts
-  from Googles CDN. For more information on the variable font, see:
+  from Google's CDN. For more information on the variable font, see:
   https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
 */
 

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -3,6 +3,7 @@ export const createIcon = ({ name, filled = false, size = 'medium', weight = 'no
   icon.innerText = name
 
   icon.className = [
+    'icon',
     'material-symbols-outlined',
     filled ? 'icon--filled' : '',
     size === 'medium' ? '' : `icon--${size}`,

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -15,6 +15,23 @@ import { createAlert } from '../Alert/Alert.js'
 ></div>
 
 Icon classes are built on top of [Google's Material Symbols Icon Font](https://fonts.google.com/icons). They provide a way to integrate iconography into your application in a flexible and customizable way.
+Optics ships with a simplified version of [Material Symbols Outlined](https://fonts.google.com/icons?icon.style=Outlined). We only include the font weight variable aspect of the library.
+This means that adjusting the size and font weight are always available, but the emphasis and fill options below are not available by default. If your app would like to use these options, you can import the full library by using the [Icon Font Addon](?path=/docs/overview-addons--docs#icon-fonts).
+
+If you don't need the full library, but want a specific axis of the [Variable Font](?path=/docs/tokens-typography-font-family--docs#variable-fonts), You can use one of these imports alongside the Optics import.
+
+```css
+/* No fill, weight, or emphasis options, just allows for size modifiers */
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block';
+
+/* Only fill option */
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1&display=block';
+
+/* Only emphasis option */
+@import 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,GRAD@20..48,-50..200&display=block';
+```
+
+A combination of these could be used as well based on your applications needs. See [Google Variable Fonts](https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts) for more details.
 
 ## Playground
 

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -37,7 +37,7 @@ Icon can be used as a standalone component, however, it does have a few dependen
 
 ### Default
 
-To use an icon, put an element (usually a `span`) with the class of `.material-symbols-outlined` and inner text of whatever icon you wish to use I.E. `settings` onto the page.
+To use an icon, put a `span` with the class of `.material-symbols-outlined` and inner text of whatever icon you wish to use I.E. `settings` onto the page.
 
 ```html
 <span class="material-symbols-outlined">settings</span>
@@ -53,7 +53,7 @@ To use an icon, put an element (usually a `span`) with the class of `.material-s
 
 ### Size
 
-`.icon--medium`, `.icon--large`, `.icon--x-large` (with medium being the default) modify the size of any icon.
+`.icon--small`, `.icon--medium`, `.icon--large`, `.icon--x-large` (with medium being the default) modify the size of any icon.
 
 <Canvas of={IconStories.Large} />
 

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -56,10 +56,10 @@ Icon can be used as a standalone component, however, it does have a few dependen
 
 ### Default
 
-To use an icon, put a `span` with the class of `.material-symbols-outlined` and inner text of whatever icon you wish to use I.E. `settings` onto the page.
+To use an icon, put a `span` with the class of `.icon.material-symbols-outlined` and inner text of whatever icon you wish to use I.E. `settings` onto the page.
 
 ```html
-<span class="material-symbols-outlined">settings</span>
+<span class="icon material-symbols-outlined">settings</span>
 ```
 
 <Canvas of={IconStories.Default} />
@@ -138,11 +138,10 @@ Here are the variables that can be customized:
 
 The icon classes are structured using the [BEM methodology](https://getbem.com/naming).
 
-This allows us to define core styles on a main [block](https://getbem.com/naming/#block) class, and use [modifiers](https://getbem.com/naming/#modifier) to encapsulate variant styles. You can modify all icon behavior by overriding the `.material-symbols-outlined` and `.custom-icons` selectors and setting any properties:
+This allows us to define core styles on a main [block](https://getbem.com/naming/#block) class, and use [modifiers](https://getbem.com/naming/#modifier) to encapsulate variant styles. You can modify all icon behavior by overriding the `.icon` selector and setting any properties:
 
 ```css
-.material-symbols-outlined,
-.custom-icons {
+.icon {
 }
 ```
 
@@ -160,8 +159,7 @@ This allows us to define core styles on a main [block](https://getbem.com/naming
 Your application may need a variation. To add one, just follow this template. Note the double hyphen, indicating that this is a [modifier](https://getbem.com/naming/#modifier):
 
 ```css
-.material-symbols-outlined,
-.custom-icons {
+.icon {
   &.icon--{name} {
     --_op-icon-font-size-small: var(--op-font-small);
   }

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -2,6 +2,8 @@ import { Meta, Story, Canvas, Controls } from '@storybook/blocks'
 import * as IconStories from './Icon.stories'
 import { createSourceCodeLink } from '../../helpers/sourceCodeLink.js'
 
+import { createAlert } from '../Alert/Alert.js'
+
 <Meta of={IconStories} />
 
 # Icon
@@ -70,3 +72,81 @@ Emphasis acts similarly to weight, but changes the thickness of the icon strokes
 `.icon--low-emphasis`, `.icon--normal-emphasis`, `.icon--high-emphasis` (with normal being the default) modify the emphasis of any icon.
 
 <Canvas of={IconStories.Emphasis} />
+
+## Icon API
+
+Styles are built on CSS variables scoped to the icon.
+
+Here are the variables that can be customized:
+
+{/* prettier-ignore-start */}
+```css
+/* Weight */
+--_op-icon-weight-light
+--_op-icon-weight-normal
+--_op-icon-weight-semi-bold
+--_op-icon-weight-bold
+
+/* Fill */
+--_op-icon-fill-outlined
+--_op-icon-fill-filled
+
+/* Emphasis */
+--_op-icon-emphasis-low
+--_op-icon-emphasis-normal
+--_op-icon-emphasis-high
+
+/* Size */
+--_op-icon-font-size-small
+--_op-icon-font-size-medium
+--_op-icon-font-size-large
+--_op-icon-font-size-x-large
+--_op-icon-optical-size-small
+--_op-icon-optical-size-medium
+--_op-icon-optical-size-large
+--_op-icon-optical-size-x-large
+```
+{/* prettier-ignore-end */}
+
+## Customizing Icon styles
+
+<div
+  dangerouslySetInnerHTML={{
+    __html: createAlert({
+      title: 'Important!',
+      description: 'These patterns represent how to customize the style of the icon for your project.',
+    }).outerHTML,
+  }}
+></div>
+
+The icon classes are structured using the [BEM methodology](https://getbem.com/naming).
+
+This allows us to define core styles on a main [block](https://getbem.com/naming/#block) class, and use [modifiers](https://getbem.com/naming/#modifier) to encapsulate variant styles. You can modify all icon behavior by overriding the `.material-symbols-outlined` and `.custom-icons` selectors and setting any properties:
+
+```css
+.material-symbols-outlined,
+.custom-icons {
+}
+```
+
+## New Icon Variations
+
+<div
+  dangerouslySetInnerHTML={{
+    __html: createAlert({
+      title: 'Important!',
+      description: 'These patterns represent how to create new variations of the icon for your project.',
+    }).outerHTML,
+  }}
+></div>
+
+Your application may need a variation. To add one, just follow this template. Note the double hyphen, indicating that this is a [modifier](https://getbem.com/naming/#modifier):
+
+```css
+.material-symbols-outlined,
+.custom-icons {
+  &.icon--{name} {
+    --_op-icon-font-size-small: var(--op-font-small);
+  }
+}
+```

--- a/src/stories/Components/Icon/Icon.stories.js
+++ b/src/stories/Components/Icon/Icon.stories.js
@@ -10,7 +10,7 @@ export default {
     filled: { control: 'boolean' },
     size: {
       control: { type: 'select' },
-      options: ['normal', 'large', 'x-large'],
+      options: ['small', 'medium', 'large', 'x-large'],
     },
     weight: {
       control: { type: 'select' },

--- a/src/stories/Overview/Addons.mdx
+++ b/src/stories/Overview/Addons.mdx
@@ -13,6 +13,21 @@ import { createSourceCodeLink } from '../helpers/sourceCodeLink.js'
 
 Optics provides a few addons for integrating Third-Party tools with your application.
 
+## Icon Fonts
+
+Optics ships with a simplified version of [Material Symbols Outlined](https://fonts.google.com/icons?icon.style=Outlined). It only includes the font weight variable aspect of the icon library which means you won't be able to utilize the fill, or emphasis properties.
+This is a trade-off for a smaller file size which reduces page load "flash-in" where icons are blank until the font has loaded.
+This flash has been mitigated some by using the `font-display: block;` property on the font face to hide the underlying text until loaded as well as a fixed size to prevent layout shift.
+
+If your app does want to use the full Material Symbols Outlined library, you can import the full library by using the following addon.
+This will increase the page load time but will allow you to use the full capabilities of the icon library.
+
+```css
+@import '@rolemodel/optics';
+
+@import '@rolemodel/optics/dist/css/addons/fonts/material_symbols_outlined_variable';
+```
+
 ## Tom Select
 
 [Tom Select](https://tom-select.js.org/) is a dynamic, framework agnostic, and lightweight (~16kb gzipped) `<select>` UI control. With autocomplete and native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, and so on.


### PR DESCRIPTION
## Why?

In order to improve the out of the box Optics experience as well as the ease of customizing icons, changes to how the component was built were needed. Additionally some performance improvements were made to reduce initial page load time

## What Changed

- [X] Update the API of icons to match other components and allow for easier customization
- [X] Add an `.icon--small` modifier
- [X] Extract `.icon` as a necessary class to be used in conjunction with `.material-symbols-outlined`. This make a clear separation from what is generally needed for an icon and what is specific for material symbols. This also sets the stage for future icon pack support.
- [X] Add documentation around those changes and how to override
- [X] Simplify the icon font import to only include the weight axis of the variable font.
- [X] Remove the layout shift while icons are loading
- [X] Make an addon to bring back in the full variable icon font to use emphasis and fill.
- [X] Add documentation around how to use the addon or variations of it.

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- [X] Have you updated the dependency graph with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- [X] Do you need to update the package version?

## Screenshots

<img width="1095" alt="Screenshot 2025-02-11 at 1 54 37 PM" src="https://github.com/user-attachments/assets/c636d86d-516e-4b17-8c3f-1de6826ed772" />
<img width="1081" alt="Screenshot 2025-02-11 at 2 02 49 PM" src="https://github.com/user-attachments/assets/665f07f9-fe53-4165-a9fc-d9fdc908b775" />
<img width="847" alt="Screenshot 2025-02-11 at 2 03 15 PM" src="https://github.com/user-attachments/assets/77be7d30-1d87-49af-bee5-19def7673bf3" />

### Old Icon loading
![Kapture 2025-02-11 at 14 16 52](https://github.com/user-attachments/assets/ce2b38ac-d5c8-4505-bb2a-63118aa8c065)

### New Icon loading
![Kapture 2025-02-11 at 14 15 06](https://github.com/user-attachments/assets/78be14fa-6ca3-4e2c-b6ff-fe58d05eef52)
