### PR TITLE
[OP-28] Custom Icon Support

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -3,6 +3,7 @@
 @import '../src/addons/fonts/phosphor_icons';
 @import '../src/addons/fonts/tabler_icons';
 @import '../src/addons/fonts/feather_icons';
+@import '../src/addons/fonts/lucide_icons';
 
 @import '../src/recipes/domains-sidebar';
 @import '../src/recipes/16six-sidebar';

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,5 +1,6 @@
 @import '../src/optics';
 @import '../src/addons/fonts/material_symbols_outlined_variable';
+@import '../src/addons/fonts/phosphor_icons';
 
 @import '../src/recipes/domains-sidebar';
 @import '../src/recipes/16six-sidebar';

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,6 +1,7 @@
 @import '../src/optics';
 @import '../src/addons/fonts/material_symbols_outlined_variable';
 @import '../src/addons/fonts/phosphor_icons';
+@import '../src/addons/fonts/tabler_icons';
 
 @import '../src/recipes/domains-sidebar';
 @import '../src/recipes/16six-sidebar';

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -2,6 +2,7 @@
 @import '../src/addons/fonts/material_symbols_outlined_variable';
 @import '../src/addons/fonts/phosphor_icons';
 @import '../src/addons/fonts/tabler_icons';
+@import '../src/addons/fonts/feather_icons';
 
 @import '../src/recipes/domains-sidebar';
 @import '../src/recipes/16six-sidebar';

--- a/src/addons/fonts/feather_icons.css
+++ b/src/addons/fonts/feather_icons.css
@@ -1,0 +1,7 @@
+/*
+  See all icons at: https://feathericons.com/
+  Icons provided via https://github.com/AT-UI/feather-font
+  Current version: 4.29.0
+*/
+
+@import 'https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.css';

--- a/src/addons/fonts/feather_icons.css
+++ b/src/addons/fonts/feather_icons.css
@@ -1,7 +1,939 @@
 /*
   See all icons at: https://feathericons.com/
   Icons provided via https://github.com/AT-UI/feather-font
+  Icons extracted from https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.css
+  The CDN provided selectors did not use a prefix to avoid naming conflicts
   Current version: 4.29.0
 */
 
-@import 'https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.css';
+/* Feather Icons */
+@font-face {
+  font-family: 'feather';
+  src: url('https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.eot?t=1501828829848'); /* IE9*/
+  src:
+    url('https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.eot?t=1501828829848#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.woff?t=1501828829848') format('woff'),
+    /* chrome, firefox */ url('https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.ttf?t=1501828829848') format('truetype'),
+    /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
+      url('https://at.alicdn.com/t/font_o5hd5vvqpoqiwwmi.svg?t=1501828829848#feather') format('svg'); /* iOS 4.1- */
+}
+
+.fi {
+  font-family: 'feather' !important;
+  font-size: var(--__op-icon-font-size);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: normal;
+}
+
+.fi-alert-octagon:before {
+  content: '\e81b';
+}
+
+.fi-alert-circle:before {
+  content: '\e81c';
+}
+
+.fi-activity:before {
+  content: '\e81d';
+}
+
+.fi-alert-triangle:before {
+  content: '\e81e';
+}
+
+.fi-align-center:before {
+  content: '\e81f';
+}
+
+.fi-airplay:before {
+  content: '\e820';
+}
+
+.fi-align-justify:before {
+  content: '\e821';
+}
+
+.fi-align-left:before {
+  content: '\e822';
+}
+
+.fi-align-right:before {
+  content: '\e823';
+}
+
+.fi-arrow-down-left:before {
+  content: '\e824';
+}
+
+.fi-arrow-down-right:before {
+  content: '\e825';
+}
+
+.fi-anchor:before {
+  content: '\e826';
+}
+
+.fi-aperture:before {
+  content: '\e827';
+}
+
+.fi-arrow-left:before {
+  content: '\e828';
+}
+
+.fi-arrow-right:before {
+  content: '\e829';
+}
+
+.fi-arrow-down:before {
+  content: '\e82a';
+}
+
+.fi-arrow-up-left:before {
+  content: '\e82b';
+}
+
+.fi-arrow-up-right:before {
+  content: '\e82c';
+}
+
+.fi-arrow-up:before {
+  content: '\e82d';
+}
+
+.fi-award:before {
+  content: '\e82e';
+}
+
+.fi-bar-chart:before {
+  content: '\e82f';
+}
+
+.fi-at-sign:before {
+  content: '\e830';
+}
+
+.fi-bar-chart-:before {
+  content: '\e831';
+}
+
+.fi-battery-charging:before {
+  content: '\e832';
+}
+
+.fi-bell-off:before {
+  content: '\e833';
+}
+
+.fi-battery:before {
+  content: '\e834';
+}
+
+.fi-bluetooth:before {
+  content: '\e835';
+}
+
+.fi-bell:before {
+  content: '\e836';
+}
+
+.fi-book:before {
+  content: '\e837';
+}
+
+.fi-briefcase:before {
+  content: '\e838';
+}
+
+.fi-camera-off:before {
+  content: '\e839';
+}
+
+.fi-calendar:before {
+  content: '\e83a';
+}
+
+.fi-bookmark:before {
+  content: '\e83b';
+}
+
+.fi-box:before {
+  content: '\e83c';
+}
+
+.fi-camera:before {
+  content: '\e83d';
+}
+
+.fi-check-circle:before {
+  content: '\e83e';
+}
+
+.fi-check:before {
+  content: '\e83f';
+}
+
+.fi-check-square:before {
+  content: '\e840';
+}
+
+.fi-cast:before {
+  content: '\e841';
+}
+
+.fi-chevron-down:before {
+  content: '\e842';
+}
+
+.fi-chevron-left:before {
+  content: '\e843';
+}
+
+.fi-chevron-right:before {
+  content: '\e844';
+}
+
+.fi-chevron-up:before {
+  content: '\e845';
+}
+
+.fi-chevrons-down:before {
+  content: '\e846';
+}
+
+.fi-chevrons-right:before {
+  content: '\e847';
+}
+
+.fi-chevrons-up:before {
+  content: '\e848';
+}
+
+.fi-chevrons-left:before {
+  content: '\e849';
+}
+
+.fi-circle:before {
+  content: '\e84a';
+}
+
+.fi-clipboard:before {
+  content: '\e84b';
+}
+
+.fi-chrome:before {
+  content: '\e84c';
+}
+
+.fi-clock:before {
+  content: '\e84d';
+}
+
+.fi-cloud-lightning:before {
+  content: '\e84e';
+}
+
+.fi-cloud-drizzle:before {
+  content: '\e84f';
+}
+
+.fi-cloud-rain:before {
+  content: '\e850';
+}
+
+.fi-cloud-off:before {
+  content: '\e851';
+}
+
+.fi-codepen:before {
+  content: '\e852';
+}
+
+.fi-cloud-snow:before {
+  content: '\e853';
+}
+
+.fi-compass:before {
+  content: '\e854';
+}
+
+.fi-copy:before {
+  content: '\e855';
+}
+
+.fi-corner-down-right:before {
+  content: '\e856';
+}
+
+.fi-corner-down-left:before {
+  content: '\e857';
+}
+
+.fi-corner-left-down:before {
+  content: '\e858';
+}
+
+.fi-corner-left-up:before {
+  content: '\e859';
+}
+
+.fi-corner-up-left:before {
+  content: '\e85a';
+}
+
+.fi-corner-up-right:before {
+  content: '\e85b';
+}
+
+.fi-corner-right-down:before {
+  content: '\e85c';
+}
+
+.fi-corner-right-up:before {
+  content: '\e85d';
+}
+
+.fi-cpu:before {
+  content: '\e85e';
+}
+
+.fi-credit-card:before {
+  content: '\e85f';
+}
+
+.fi-crosshair:before {
+  content: '\e860';
+}
+
+.fi-disc:before {
+  content: '\e861';
+}
+
+.fi-delete:before {
+  content: '\e862';
+}
+
+.fi-download-cloud:before {
+  content: '\e863';
+}
+
+.fi-download:before {
+  content: '\e864';
+}
+
+.fi-droplet:before {
+  content: '\e865';
+}
+
+.fi-edit-:before {
+  content: '\e866';
+}
+
+.fi-edit:before {
+  content: '\e867';
+}
+
+.fi-edit-1:before {
+  content: '\e868';
+}
+
+.fi-external-link:before {
+  content: '\e869';
+}
+
+.fi-eye:before {
+  content: '\e86a';
+}
+
+.fi-feather:before {
+  content: '\e86b';
+}
+
+.fi-facebook:before {
+  content: '\e86c';
+}
+
+.fi-file-minus:before {
+  content: '\e86d';
+}
+
+.fi-eye-off:before {
+  content: '\e86e';
+}
+
+.fi-fast-forward:before {
+  content: '\e86f';
+}
+
+.fi-file-text:before {
+  content: '\e870';
+}
+
+.fi-film:before {
+  content: '\e871';
+}
+
+.fi-file:before {
+  content: '\e872';
+}
+
+.fi-file-plus:before {
+  content: '\e873';
+}
+
+.fi-folder:before {
+  content: '\e874';
+}
+
+.fi-filter:before {
+  content: '\e875';
+}
+
+.fi-flag:before {
+  content: '\e876';
+}
+
+.fi-globe:before {
+  content: '\e877';
+}
+
+.fi-grid:before {
+  content: '\e878';
+}
+
+.fi-heart:before {
+  content: '\e879';
+}
+
+.fi-home:before {
+  content: '\e87a';
+}
+
+.fi-github:before {
+  content: '\e87b';
+}
+
+.fi-image:before {
+  content: '\e87c';
+}
+
+.fi-inbox:before {
+  content: '\e87d';
+}
+
+.fi-layers:before {
+  content: '\e87e';
+}
+
+.fi-info:before {
+  content: '\e87f';
+}
+
+.fi-instagram:before {
+  content: '\e880';
+}
+
+.fi-layout:before {
+  content: '\e881';
+}
+
+.fi-link-:before {
+  content: '\e882';
+}
+
+.fi-life-buoy:before {
+  content: '\e883';
+}
+
+.fi-link:before {
+  content: '\e884';
+}
+
+.fi-log-in:before {
+  content: '\e885';
+}
+
+.fi-list:before {
+  content: '\e886';
+}
+
+.fi-lock:before {
+  content: '\e887';
+}
+
+.fi-log-out:before {
+  content: '\e888';
+}
+
+.fi-loader:before {
+  content: '\e889';
+}
+
+.fi-mail:before {
+  content: '\e88a';
+}
+
+.fi-maximize-:before {
+  content: '\e88b';
+}
+
+.fi-map:before {
+  content: '\e88c';
+}
+
+.fi-maximize:before {
+  content: '\e88d';
+}
+
+.fi-map-pin:before {
+  content: '\e88e';
+}
+
+.fi-menu:before {
+  content: '\e88f';
+}
+
+.fi-message-circle:before {
+  content: '\e890';
+}
+
+.fi-message-square:before {
+  content: '\e891';
+}
+
+.fi-minimize-:before {
+  content: '\e892';
+}
+
+.fi-mic-off:before {
+  content: '\e893';
+}
+
+.fi-minus-circle:before {
+  content: '\e894';
+}
+
+.fi-mic:before {
+  content: '\e895';
+}
+
+.fi-minus-square:before {
+  content: '\e896';
+}
+
+.fi-minus:before {
+  content: '\e897';
+}
+
+.fi-moon:before {
+  content: '\e898';
+}
+
+.fi-monitor:before {
+  content: '\e899';
+}
+
+.fi-more-vertical:before {
+  content: '\e89a';
+}
+
+.fi-more-horizontal:before {
+  content: '\e89b';
+}
+
+.fi-move:before {
+  content: '\e89c';
+}
+
+.fi-music:before {
+  content: '\e89d';
+}
+
+.fi-navigation-:before {
+  content: '\e89e';
+}
+
+.fi-navigation:before {
+  content: '\e89f';
+}
+
+.fi-octagon:before {
+  content: '\e8a0';
+}
+
+.fi-package:before {
+  content: '\e8a1';
+}
+
+.fi-pause-circle:before {
+  content: '\e8a2';
+}
+
+.fi-pause:before {
+  content: '\e8a3';
+}
+
+.fi-percent:before {
+  content: '\e8a4';
+}
+
+.fi-phone-call:before {
+  content: '\e8a5';
+}
+
+.fi-phone-forwarded:before {
+  content: '\e8a6';
+}
+
+.fi-phone-missed:before {
+  content: '\e8a7';
+}
+
+.fi-phone-off:before {
+  content: '\e8a8';
+}
+
+.fi-phone-incoming:before {
+  content: '\e8a9';
+}
+
+.fi-phone:before {
+  content: '\e8aa';
+}
+
+.fi-phone-outgoing:before {
+  content: '\e8ab';
+}
+
+.fi-pie-chart:before {
+  content: '\e8ac';
+}
+
+.fi-play-circle:before {
+  content: '\e8ad';
+}
+
+.fi-play:before {
+  content: '\e8ae';
+}
+
+.fi-plus-square:before {
+  content: '\e8af';
+}
+
+.fi-plus-circle:before {
+  content: '\e8b0';
+}
+
+.fi-plus:before {
+  content: '\e8b1';
+}
+
+.fi-pocket:before {
+  content: '\e8b2';
+}
+
+.fi-printer:before {
+  content: '\e8b3';
+}
+
+.fi-power:before {
+  content: '\e8b4';
+}
+
+.fi-radio:before {
+  content: '\e8b5';
+}
+
+.fi-repeat:before {
+  content: '\e8b6';
+}
+
+.fi-refresh-ccw:before {
+  content: '\e8b7';
+}
+
+.fi-rewind:before {
+  content: '\e8b8';
+}
+
+.fi-rotate-ccw:before {
+  content: '\e8b9';
+}
+
+.fi-refresh-cw:before {
+  content: '\e8ba';
+}
+
+.fi-rotate-cw:before {
+  content: '\e8bb';
+}
+
+.fi-save:before {
+  content: '\e8bc';
+}
+
+.fi-search:before {
+  content: '\e8bd';
+}
+
+.fi-server:before {
+  content: '\e8be';
+}
+
+.fi-scissors:before {
+  content: '\e8bf';
+}
+
+.fi-share-:before {
+  content: '\e8c0';
+}
+
+.fi-share:before {
+  content: '\e8c1';
+}
+
+.fi-shield:before {
+  content: '\e8c2';
+}
+
+.fi-settings:before {
+  content: '\e8c3';
+}
+
+.fi-skip-back:before {
+  content: '\e8c4';
+}
+
+.fi-shuffle:before {
+  content: '\e8c5';
+}
+
+.fi-sidebar:before {
+  content: '\e8c6';
+}
+
+.fi-skip-forward:before {
+  content: '\e8c7';
+}
+
+.fi-slack:before {
+  content: '\e8c8';
+}
+
+.fi-slash:before {
+  content: '\e8c9';
+}
+
+.fi-smartphone:before {
+  content: '\e8ca';
+}
+
+.fi-square:before {
+  content: '\e8cb';
+}
+
+.fi-speaker:before {
+  content: '\e8cc';
+}
+
+.fi-star:before {
+  content: '\e8cd';
+}
+
+.fi-stop-circle:before {
+  content: '\e8ce';
+}
+
+.fi-sun:before {
+  content: '\e8cf';
+}
+
+.fi-sunrise:before {
+  content: '\e8d0';
+}
+
+.fi-tablet:before {
+  content: '\e8d1';
+}
+
+.fi-tag:before {
+  content: '\e8d2';
+}
+
+.fi-sunset:before {
+  content: '\e8d3';
+}
+
+.fi-target:before {
+  content: '\e8d4';
+}
+
+.fi-thermometer:before {
+  content: '\e8d5';
+}
+
+.fi-thumbs-up:before {
+  content: '\e8d6';
+}
+
+.fi-thumbs-down:before {
+  content: '\e8d7';
+}
+
+.fi-toggle-left:before {
+  content: '\e8d8';
+}
+
+.fi-toggle-right:before {
+  content: '\e8d9';
+}
+
+.fi-trash-:before {
+  content: '\e8da';
+}
+
+.fi-trash:before {
+  content: '\e8db';
+}
+
+.fi-trending-up:before {
+  content: '\e8dc';
+}
+
+.fi-trending-down:before {
+  content: '\e8dd';
+}
+
+.fi-triangle:before {
+  content: '\e8de';
+}
+
+.fi-type:before {
+  content: '\e8df';
+}
+
+.fi-twitter:before {
+  content: '\e8e0';
+}
+
+.fi-upload:before {
+  content: '\e8e1';
+}
+
+.fi-umbrella:before {
+  content: '\e8e2';
+}
+
+.fi-upload-cloud:before {
+  content: '\e8e3';
+}
+
+.fi-unlock:before {
+  content: '\e8e4';
+}
+
+.fi-user-check:before {
+  content: '\e8e5';
+}
+
+.fi-user-minus:before {
+  content: '\e8e6';
+}
+
+.fi-user-plus:before {
+  content: '\e8e7';
+}
+
+.fi-user-x:before {
+  content: '\e8e8';
+}
+
+.fi-user:before {
+  content: '\e8e9';
+}
+
+.fi-users:before {
+  content: '\e8ea';
+}
+
+.fi-video-off:before {
+  content: '\e8eb';
+}
+
+.fi-video:before {
+  content: '\e8ec';
+}
+
+.fi-voicemail:before {
+  content: '\e8ed';
+}
+
+.fi-volume-x:before {
+  content: '\e8ee';
+}
+
+.fi-volume-:before {
+  content: '\e8ef';
+}
+
+.fi-volume-1:before {
+  content: '\e8f0';
+}
+
+.fi-volume:before {
+  content: '\e8f1';
+}
+
+.fi-watch:before {
+  content: '\e8f2';
+}
+
+.fi-wifi:before {
+  content: '\e8f3';
+}
+
+.fi-x-square:before {
+  content: '\e8f4';
+}
+
+.fi-wind:before {
+  content: '\e8f5';
+}
+
+.fi-x:before {
+  content: '\e8f6';
+}
+
+.fi-x-circle:before {
+  content: '\e8f7';
+}
+
+.fi-zap:before {
+  content: '\e8f8';
+}
+
+.fi-zoom-in:before {
+  content: '\e8f9';
+}
+
+.fi-zoom-out:before {
+  content: '\e8fa';
+}
+
+.fi-command:before {
+  content: '\e8fb';
+}
+
+.fi-cloud:before {
+  content: '\e8fc';
+}
+
+.fi-hash:before {
+  content: '\e8fd';
+}
+
+.fi-headphones:before {
+  content: '\e8fe';
+}

--- a/src/addons/fonts/lucide_icons.css
+++ b/src/addons/fonts/lucide_icons.css
@@ -1,0 +1,4672 @@
+/*
+  See all icons at: https://lucide.dev/icons/
+  Icons extracted from https://unpkg.com/lucide-static@0.473.0/font/lucide.css
+  The CDN provided selectors did not use a prefix to avoid naming conflicts
+  Current version: 0.473.0
+*/
+
+/* Lucide Icons */
+@font-face {
+  font-family: 'lucide';
+  src: url('https://unpkg.com/lucide-static@0.473.0/font/lucide.eot?t=1737128053459'); /* IE9*/
+  src:
+    url('https://unpkg.com/lucide-static@0.473.0/font/lucide.eot?t=1737128053459#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://unpkg.com/lucide-static@0.473.0/font/lucide.woff2?t=1737128053459') format('woff2'),
+    url('https://unpkg.com/lucide-static@0.473.0/font/lucide.woff?t=1737128053459') format('woff'),
+    url('https://unpkg.com/lucide-static@0.473.0/font/lucide.ttf?t=1737128053459') format('truetype'),
+    /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
+      url('https://unpkg.com/lucide-static@0.473.0/font/lucide.svg?t=1737128053459#lucide') format('svg'); /* iOS 4.1- */
+}
+
+.li {
+  font-family: 'lucide' !important;
+  font-size: var(--__op-icon-font-size);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: normal;
+}
+
+.li-a-arrow-down:before {
+  content: '\e589';
+}
+.li-a-arrow-up:before {
+  content: '\e58a';
+}
+.li-a-large-small:before {
+  content: '\e58b';
+}
+.li-accessibility:before {
+  content: '\e296';
+}
+.li-activity:before {
+  content: '\e038';
+}
+.li-air-vent:before {
+  content: '\e350';
+}
+.li-airplay:before {
+  content: '\e039';
+}
+.li-alarm-clock-check:before {
+  content: '\e1eb';
+}
+.li-alarm-clock-minus:before {
+  content: '\e1ec';
+}
+.li-alarm-clock-off:before {
+  content: '\e23a';
+}
+.li-alarm-clock-plus:before {
+  content: '\e1ed';
+}
+.li-alarm-clock:before {
+  content: '\e03a';
+}
+.li-alarm-smoke:before {
+  content: '\e57f';
+}
+.li-album:before {
+  content: '\e03b';
+}
+.li-align-center-horizontal:before {
+  content: '\e26b';
+}
+.li-align-center-vertical:before {
+  content: '\e26c';
+}
+.li-align-center:before {
+  content: '\e03c';
+}
+.li-align-end-horizontal:before {
+  content: '\e26d';
+}
+.li-align-end-vertical:before {
+  content: '\e26e';
+}
+.li-align-horizontal-distribute-center:before {
+  content: '\e03d';
+}
+.li-align-horizontal-distribute-end:before {
+  content: '\e03e';
+}
+.li-align-horizontal-distribute-start:before {
+  content: '\e03f';
+}
+.li-align-horizontal-justify-center:before {
+  content: '\e271';
+}
+.li-align-horizontal-justify-end:before {
+  content: '\e272';
+}
+.li-align-horizontal-justify-start:before {
+  content: '\e273';
+}
+.li-align-horizontal-space-around:before {
+  content: '\e274';
+}
+.li-align-horizontal-space-between:before {
+  content: '\e275';
+}
+.li-align-justify:before {
+  content: '\e040';
+}
+.li-align-left:before {
+  content: '\e041';
+}
+.li-align-right:before {
+  content: '\e042';
+}
+.li-align-start-horizontal:before {
+  content: '\e26f';
+}
+.li-align-start-vertical:before {
+  content: '\e270';
+}
+.li-align-vertical-distribute-center:before {
+  content: '\e27d';
+}
+.li-align-vertical-distribute-end:before {
+  content: '\e27e';
+}
+.li-align-vertical-distribute-start:before {
+  content: '\e27f';
+}
+.li-align-vertical-justify-center:before {
+  content: '\e276';
+}
+.li-align-vertical-justify-end:before {
+  content: '\e277';
+}
+.li-align-vertical-justify-start:before {
+  content: '\e278';
+}
+.li-align-vertical-space-around:before {
+  content: '\e279';
+}
+.li-align-vertical-space-between:before {
+  content: '\e27a';
+}
+.li-ambulance:before {
+  content: '\e5bf';
+}
+.li-ampersand:before {
+  content: '\e4a0';
+}
+.li-ampersands:before {
+  content: '\e4a1';
+}
+.li-amphora:before {
+  content: '\e61f';
+}
+.li-anchor:before {
+  content: '\e043';
+}
+.li-angry:before {
+  content: '\e2fb';
+}
+.li-annoyed:before {
+  content: '\e2fc';
+}
+.li-antenna:before {
+  content: '\e4e6';
+}
+.li-anvil:before {
+  content: '\e584';
+}
+.li-aperture:before {
+  content: '\e044';
+}
+.li-app-window-mac:before {
+  content: '\e5d6';
+}
+.li-app-window:before {
+  content: '\e42a';
+}
+.li-apple:before {
+  content: '\e351';
+}
+.li-archive-restore:before {
+  content: '\e2cc';
+}
+.li-archive-x:before {
+  content: '\e510';
+}
+.li-archive:before {
+  content: '\e045';
+}
+.li-armchair:before {
+  content: '\e2bf';
+}
+.li-arrow-big-down-dash:before {
+  content: '\e421';
+}
+.li-arrow-big-down:before {
+  content: '\e1e0';
+}
+.li-arrow-big-left-dash:before {
+  content: '\e422';
+}
+.li-arrow-big-left:before {
+  content: '\e1e1';
+}
+.li-arrow-big-right-dash:before {
+  content: '\e423';
+}
+.li-arrow-big-right:before {
+  content: '\e1e2';
+}
+.li-arrow-big-up-dash:before {
+  content: '\e424';
+}
+.li-arrow-big-up:before {
+  content: '\e1e3';
+}
+.li-arrow-down-0-1:before {
+  content: '\e417';
+}
+.li-arrow-down-1-0:before {
+  content: '\e418';
+}
+.li-arrow-down-a-z:before {
+  content: '\e419';
+}
+.li-arrow-down-from-line:before {
+  content: '\e458';
+}
+.li-arrow-down-left:before {
+  content: '\e047';
+}
+.li-arrow-down-narrow-wide:before {
+  content: '\e048';
+}
+.li-arrow-down-right:before {
+  content: '\e049';
+}
+.li-arrow-down-to-dot:before {
+  content: '\e451';
+}
+.li-arrow-down-to-line:before {
+  content: '\e459';
+}
+.li-arrow-down-up:before {
+  content: '\e04a';
+}
+.li-arrow-down-wide-narrow:before {
+  content: '\e04b';
+}
+.li-arrow-down-z-a:before {
+  content: '\e41a';
+}
+.li-arrow-down:before {
+  content: '\e046';
+}
+.li-arrow-left-from-line:before {
+  content: '\e45a';
+}
+.li-arrow-left-right:before {
+  content: '\e249';
+}
+.li-arrow-left-to-line:before {
+  content: '\e45b';
+}
+.li-arrow-left:before {
+  content: '\e04c';
+}
+.li-arrow-right-from-line:before {
+  content: '\e45c';
+}
+.li-arrow-right-left:before {
+  content: '\e41b';
+}
+.li-arrow-right-to-line:before {
+  content: '\e45d';
+}
+.li-arrow-right:before {
+  content: '\e04d';
+}
+.li-arrow-up-0-1:before {
+  content: '\e41c';
+}
+.li-arrow-up-1-0:before {
+  content: '\e41d';
+}
+.li-arrow-up-a-z:before {
+  content: '\e41e';
+}
+.li-arrow-up-down:before {
+  content: '\e380';
+}
+.li-arrow-up-from-dot:before {
+  content: '\e452';
+}
+.li-arrow-up-from-line:before {
+  content: '\e45e';
+}
+.li-arrow-up-left:before {
+  content: '\e04f';
+}
+.li-arrow-up-narrow-wide:before {
+  content: '\e050';
+}
+.li-arrow-up-right:before {
+  content: '\e051';
+}
+.li-arrow-up-to-line:before {
+  content: '\e45f';
+}
+.li-arrow-up-wide-narrow:before {
+  content: '\e41f';
+}
+.li-arrow-up-z-a:before {
+  content: '\e420';
+}
+.li-arrow-up:before {
+  content: '\e04e';
+}
+.li-arrows-up-from-line:before {
+  content: '\e4d8';
+}
+.li-asterisk:before {
+  content: '\e1ee';
+}
+.li-at-sign:before {
+  content: '\e052';
+}
+.li-atom:before {
+  content: '\e3da';
+}
+.li-audio-lines:before {
+  content: '\e55e';
+}
+.li-audio-waveform:before {
+  content: '\e55f';
+}
+.li-award:before {
+  content: '\e053';
+}
+.li-axe:before {
+  content: '\e054';
+}
+.li-axis-3d:before {
+  content: '\e2fd';
+}
+.li-baby:before {
+  content: '\e2cd';
+}
+.li-backpack:before {
+  content: '\e2c7';
+}
+.li-badge-alert:before {
+  content: '\e479';
+}
+.li-badge-cent:before {
+  content: '\e513';
+}
+.li-badge-check:before {
+  content: '\e240';
+}
+.li-badge-dollar-sign:before {
+  content: '\e47a';
+}
+.li-badge-euro:before {
+  content: '\e514';
+}
+.li-badge-help:before {
+  content: '\e47b';
+}
+.li-badge-indian-rupee:before {
+  content: '\e515';
+}
+.li-badge-info:before {
+  content: '\e47c';
+}
+.li-badge-japanese-yen:before {
+  content: '\e516';
+}
+.li-badge-minus:before {
+  content: '\e47d';
+}
+.li-badge-percent:before {
+  content: '\e47e';
+}
+.li-badge-plus:before {
+  content: '\e47f';
+}
+.li-badge-pound-sterling:before {
+  content: '\e517';
+}
+.li-badge-russian-ruble:before {
+  content: '\e518';
+}
+.li-badge-swiss-franc:before {
+  content: '\e519';
+}
+.li-badge-x:before {
+  content: '\e480';
+}
+.li-badge:before {
+  content: '\e478';
+}
+.li-baggage-claim:before {
+  content: '\e2c8';
+}
+.li-ban:before {
+  content: '\e055';
+}
+.li-banana:before {
+  content: '\e352';
+}
+.li-bandage:before {
+  content: '\e621';
+}
+.li-banknote:before {
+  content: '\e056';
+}
+.li-barcode:before {
+  content: '\e537';
+}
+.li-baseline:before {
+  content: '\e284';
+}
+.li-bath:before {
+  content: '\e2aa';
+}
+.li-battery-charging:before {
+  content: '\e058';
+}
+.li-battery-full:before {
+  content: '\e059';
+}
+.li-battery-low:before {
+  content: '\e05a';
+}
+.li-battery-medium:before {
+  content: '\e05b';
+}
+.li-battery-plus:before {
+  content: '\e642';
+}
+.li-battery-warning:before {
+  content: '\e3af';
+}
+.li-battery:before {
+  content: '\e057';
+}
+.li-beaker:before {
+  content: '\e05c';
+}
+.li-bean-off:before {
+  content: '\e393';
+}
+.li-bean:before {
+  content: '\e392';
+}
+.li-bed-double:before {
+  content: '\e2c1';
+}
+.li-bed-single:before {
+  content: '\e2c2';
+}
+.li-bed:before {
+  content: '\e2c0';
+}
+.li-beef:before {
+  content: '\e3a8';
+}
+.li-beer-off:before {
+  content: '\e5dd';
+}
+.li-beer:before {
+  content: '\e2ce';
+}
+.li-bell-dot:before {
+  content: '\e42f';
+}
+.li-bell-electric:before {
+  content: '\e580';
+}
+.li-bell-minus:before {
+  content: '\e1ef';
+}
+.li-bell-off:before {
+  content: '\e05e';
+}
+.li-bell-plus:before {
+  content: '\e1f0';
+}
+.li-bell-ring:before {
+  content: '\e223';
+}
+.li-bell:before {
+  content: '\e05d';
+}
+.li-between-horizontal-end:before {
+  content: '\e595';
+}
+.li-between-horizontal-start:before {
+  content: '\e596';
+}
+.li-between-vertical-end:before {
+  content: '\e597';
+}
+.li-between-vertical-start:before {
+  content: '\e598';
+}
+.li-biceps-flexed:before {
+  content: '\e5ef';
+}
+.li-bike:before {
+  content: '\e1d1';
+}
+.li-binary:before {
+  content: '\e1f1';
+}
+.li-binoculars:before {
+  content: '\e625';
+}
+.li-biohazard:before {
+  content: '\e445';
+}
+.li-bird:before {
+  content: '\e3c8';
+}
+.li-bitcoin:before {
+  content: '\e05f';
+}
+.li-blend:before {
+  content: '\e5a0';
+}
+.li-blinds:before {
+  content: '\e3c3';
+}
+.li-blocks:before {
+  content: '\e4fe';
+}
+.li-bluetooth-connected:before {
+  content: '\e1b7';
+}
+.li-bluetooth-off:before {
+  content: '\e1b8';
+}
+.li-bluetooth-searching:before {
+  content: '\e1b9';
+}
+.li-bluetooth:before {
+  content: '\e060';
+}
+.li-bold:before {
+  content: '\e061';
+}
+.li-bolt:before {
+  content: '\e590';
+}
+.li-bomb:before {
+  content: '\e2fe';
+}
+.li-bone:before {
+  content: '\e35b';
+}
+.li-book-a:before {
+  content: '\e548';
+}
+.li-book-audio:before {
+  content: '\e549';
+}
+.li-book-check:before {
+  content: '\e54a';
+}
+.li-book-copy:before {
+  content: '\e3f0';
+}
+.li-book-dashed:before {
+  content: '\e3f1';
+}
+.li-book-down:before {
+  content: '\e3f2';
+}
+.li-book-headphones:before {
+  content: '\e54b';
+}
+.li-book-heart:before {
+  content: '\e54c';
+}
+.li-book-image:before {
+  content: '\e54d';
+}
+.li-book-key:before {
+  content: '\e3f3';
+}
+.li-book-lock:before {
+  content: '\e3f4';
+}
+.li-book-marked:before {
+  content: '\e3f5';
+}
+.li-book-minus:before {
+  content: '\e3f6';
+}
+.li-book-open-check:before {
+  content: '\e384';
+}
+.li-book-open-text:before {
+  content: '\e54e';
+}
+.li-book-open:before {
+  content: '\e063';
+}
+.li-book-plus:before {
+  content: '\e3f7';
+}
+.li-book-text:before {
+  content: '\e54f';
+}
+.li-book-type:before {
+  content: '\e550';
+}
+.li-book-up-2:before {
+  content: '\e4aa';
+}
+.li-book-up:before {
+  content: '\e3f8';
+}
+.li-book-user:before {
+  content: '\e551';
+}
+.li-book-x:before {
+  content: '\e3f9';
+}
+.li-book:before {
+  content: '\e062';
+}
+.li-bookmark-check:before {
+  content: '\e523';
+}
+.li-bookmark-minus:before {
+  content: '\e23b';
+}
+.li-bookmark-plus:before {
+  content: '\e23c';
+}
+.li-bookmark-x:before {
+  content: '\e524';
+}
+.li-bookmark:before {
+  content: '\e064';
+}
+.li-boom-box:before {
+  content: '\e4f2';
+}
+.li-bot-message-square:before {
+  content: '\e5d2';
+}
+.li-bot-off:before {
+  content: '\e5e4';
+}
+.li-bot:before {
+  content: '\e1ba';
+}
+.li-box:before {
+  content: '\e065';
+}
+.li-boxes:before {
+  content: '\e2cf';
+}
+.li-braces:before {
+  content: '\e36d';
+}
+.li-brackets:before {
+  content: '\e447';
+}
+.li-brain-circuit:before {
+  content: '\e3ca';
+}
+.li-brain-cog:before {
+  content: '\e3cb';
+}
+.li-brain:before {
+  content: '\e3c9';
+}
+.li-brick-wall:before {
+  content: '\e585';
+}
+.li-briefcase-business:before {
+  content: '\e5d9';
+}
+.li-briefcase-conveyor-belt:before {
+  content: '\e62f';
+}
+.li-briefcase-medical:before {
+  content: '\e5da';
+}
+.li-briefcase:before {
+  content: '\e066';
+}
+.li-bring-to-front:before {
+  content: '\e4f3';
+}
+.li-brush:before {
+  content: '\e1d2';
+}
+.li-bug-off:before {
+  content: '\e511';
+}
+.li-bug-play:before {
+  content: '\e512';
+}
+.li-bug:before {
+  content: '\e20b';
+}
+.li-building-2:before {
+  content: '\e28f';
+}
+.li-building:before {
+  content: '\e1cb';
+}
+.li-bus-front:before {
+  content: '\e4ff';
+}
+.li-bus:before {
+  content: '\e1d3';
+}
+.li-cable-car:before {
+  content: '\e500';
+}
+.li-cable:before {
+  content: '\e4e7';
+}
+.li-cake-slice:before {
+  content: '\e4bd';
+}
+.li-cake:before {
+  content: '\e347';
+}
+.li-calculator:before {
+  content: '\e1bb';
+}
+.li-calendar-1:before {
+  content: '\e634';
+}
+.li-calendar-arrow-down:before {
+  content: '\e602';
+}
+.li-calendar-arrow-up:before {
+  content: '\e603';
+}
+.li-calendar-check-2:before {
+  content: '\e2b7';
+}
+.li-calendar-check:before {
+  content: '\e2b6';
+}
+.li-calendar-clock:before {
+  content: '\e303';
+}
+.li-calendar-cog:before {
+  content: '\e5f1';
+}
+.li-calendar-days:before {
+  content: '\e2b8';
+}
+.li-calendar-fold:before {
+  content: '\e5b8';
+}
+.li-calendar-heart:before {
+  content: '\e304';
+}
+.li-calendar-minus-2:before {
+  content: '\e5b9';
+}
+.li-calendar-minus:before {
+  content: '\e2b9';
+}
+.li-calendar-off:before {
+  content: '\e2ba';
+}
+.li-calendar-plus-2:before {
+  content: '\e5ba';
+}
+.li-calendar-plus:before {
+  content: '\e2bb';
+}
+.li-calendar-range:before {
+  content: '\e2bc';
+}
+.li-calendar-search:before {
+  content: '\e305';
+}
+.li-calendar-sync:before {
+  content: '\e63a';
+}
+.li-calendar-x-2:before {
+  content: '\e2be';
+}
+.li-calendar-x:before {
+  content: '\e2bd';
+}
+.li-calendar:before {
+  content: '\e067';
+}
+.li-camera-off:before {
+  content: '\e069';
+}
+.li-camera:before {
+  content: '\e068';
+}
+.li-candy-cane:before {
+  content: '\e4be';
+}
+.li-candy-off:before {
+  content: '\e395';
+}
+.li-candy:before {
+  content: '\e394';
+}
+.li-cannabis:before {
+  content: '\e5d8';
+}
+.li-captions-off:before {
+  content: '\e5c5';
+}
+.li-captions:before {
+  content: '\e3a7';
+}
+.li-car-front:before {
+  content: '\e501';
+}
+.li-car-taxi-front:before {
+  content: '\e502';
+}
+.li-car:before {
+  content: '\e1d4';
+}
+.li-caravan:before {
+  content: '\e53d';
+}
+.li-carrot:before {
+  content: '\e259';
+}
+.li-case-lower:before {
+  content: '\e3db';
+}
+.li-case-sensitive:before {
+  content: '\e3dc';
+}
+.li-case-upper:before {
+  content: '\e3dd';
+}
+.li-cassette-tape:before {
+  content: '\e4ce';
+}
+.li-cast:before {
+  content: '\e06a';
+}
+.li-castle:before {
+  content: '\e3e3';
+}
+.li-cat:before {
+  content: '\e38f';
+}
+.li-cctv:before {
+  content: '\e581';
+}
+.li-chart-area:before {
+  content: '\e4d7';
+}
+.li-chart-bar-big:before {
+  content: '\e4ab';
+}
+.li-chart-bar-decreasing:before {
+  content: '\e60b';
+}
+.li-chart-bar-increasing:before {
+  content: '\e60c';
+}
+.li-chart-bar-stacked:before {
+  content: '\e60d';
+}
+.li-chart-bar:before {
+  content: '\e2a1';
+}
+.li-chart-candlestick:before {
+  content: '\e4ac';
+}
+.li-chart-column-big:before {
+  content: '\e4ad';
+}
+.li-chart-column-decreasing:before {
+  content: '\e06b';
+}
+.li-chart-column-increasing:before {
+  content: '\e2a3';
+}
+.li-chart-column-stacked:before {
+  content: '\e60e';
+}
+.li-chart-column:before {
+  content: '\e2a2';
+}
+.li-chart-gantt:before {
+  content: '\e628';
+}
+.li-chart-line:before {
+  content: '\e2a4';
+}
+.li-chart-network:before {
+  content: '\e60f';
+}
+.li-chart-no-axes-column-decreasing:before {
+  content: '\e06d';
+}
+.li-chart-no-axes-column-increasing:before {
+  content: '\e06e';
+}
+.li-chart-no-axes-column:before {
+  content: '\e06c';
+}
+.li-chart-no-axes-combined:before {
+  content: '\e610';
+}
+.li-chart-no-axes-gantt:before {
+  content: '\e4c8';
+}
+.li-chart-pie:before {
+  content: '\e06f';
+}
+.li-chart-scatter:before {
+  content: '\e48e';
+}
+.li-chart-spline:before {
+  content: '\e611';
+}
+.li-check-check:before {
+  content: '\e391';
+}
+.li-check:before {
+  content: '\e070';
+}
+.li-chef-hat:before {
+  content: '\e2ab';
+}
+.li-cherry:before {
+  content: '\e353';
+}
+.li-chevron-down:before {
+  content: '\e071';
+}
+.li-chevron-first:before {
+  content: '\e242';
+}
+.li-chevron-last:before {
+  content: '\e243';
+}
+.li-chevron-left:before {
+  content: '\e072';
+}
+.li-chevron-right:before {
+  content: '\e073';
+}
+.li-chevron-up:before {
+  content: '\e074';
+}
+.li-chevrons-down-up:before {
+  content: '\e227';
+}
+.li-chevrons-down:before {
+  content: '\e075';
+}
+.li-chevrons-left-right-ellipsis:before {
+  content: '\e623';
+}
+.li-chevrons-left-right:before {
+  content: '\e292';
+}
+.li-chevrons-left:before {
+  content: '\e076';
+}
+.li-chevrons-right-left:before {
+  content: '\e293';
+}
+.li-chevrons-right:before {
+  content: '\e077';
+}
+.li-chevrons-up-down:before {
+  content: '\e210';
+}
+.li-chevrons-up:before {
+  content: '\e078';
+}
+.li-chrome:before {
+  content: '\e079';
+}
+.li-church:before {
+  content: '\e3e4';
+}
+.li-cigarette-off:before {
+  content: '\e2c6';
+}
+.li-cigarette:before {
+  content: '\e2c5';
+}
+.li-circle-alert:before {
+  content: '\e07b';
+}
+.li-circle-arrow-down:before {
+  content: '\e07c';
+}
+.li-circle-arrow-left:before {
+  content: '\e07d';
+}
+.li-circle-arrow-out-down-left:before {
+  content: '\e3fb';
+}
+.li-circle-arrow-out-down-right:before {
+  content: '\e3fc';
+}
+.li-circle-arrow-out-up-left:before {
+  content: '\e3fd';
+}
+.li-circle-arrow-out-up-right:before {
+  content: '\e3fe';
+}
+.li-circle-arrow-right:before {
+  content: '\e07e';
+}
+.li-circle-arrow-up:before {
+  content: '\e07f';
+}
+.li-circle-check-big:before {
+  content: '\e080';
+}
+.li-circle-check:before {
+  content: '\e225';
+}
+.li-circle-chevron-down:before {
+  content: '\e4e1';
+}
+.li-circle-chevron-left:before {
+  content: '\e4e2';
+}
+.li-circle-chevron-right:before {
+  content: '\e4e3';
+}
+.li-circle-chevron-up:before {
+  content: '\e4e4';
+}
+.li-circle-dashed:before {
+  content: '\e4b4';
+}
+.li-circle-divide:before {
+  content: '\e081';
+}
+.li-circle-dollar-sign:before {
+  content: '\e481';
+}
+.li-circle-dot-dashed:before {
+  content: '\e4b5';
+}
+.li-circle-dot:before {
+  content: '\e348';
+}
+.li-circle-ellipsis:before {
+  content: '\e349';
+}
+.li-circle-equal:before {
+  content: '\e404';
+}
+.li-circle-fading-arrow-up:before {
+  content: '\e61c';
+}
+.li-circle-fading-plus:before {
+  content: '\e5c0';
+}
+.li-circle-gauge:before {
+  content: '\e4e5';
+}
+.li-circle-help:before {
+  content: '\e082';
+}
+.li-circle-minus:before {
+  content: '\e083';
+}
+.li-circle-off:before {
+  content: '\e405';
+}
+.li-circle-parking-off:before {
+  content: '\e3cd';
+}
+.li-circle-parking:before {
+  content: '\e3cc';
+}
+.li-circle-pause:before {
+  content: '\e084';
+}
+.li-circle-percent:before {
+  content: '\e51e';
+}
+.li-circle-play:before {
+  content: '\e085';
+}
+.li-circle-plus:before {
+  content: '\e086';
+}
+.li-circle-power:before {
+  content: '\e554';
+}
+.li-circle-slash-2:before {
+  content: '\e212';
+}
+.li-circle-slash:before {
+  content: '\e406';
+}
+.li-circle-stop:before {
+  content: '\e087';
+}
+.li-circle-user-round:before {
+  content: '\e466';
+}
+.li-circle-user:before {
+  content: '\e465';
+}
+.li-circle-x:before {
+  content: '\e088';
+}
+.li-circle:before {
+  content: '\e07a';
+}
+.li-circuit-board:before {
+  content: '\e407';
+}
+.li-citrus:before {
+  content: '\e378';
+}
+.li-clapperboard:before {
+  content: '\e29a';
+}
+.li-clipboard-check:before {
+  content: '\e218';
+}
+.li-clipboard-copy:before {
+  content: '\e224';
+}
+.li-clipboard-list:before {
+  content: '\e08a';
+}
+.li-clipboard-minus:before {
+  content: '\e5c2';
+}
+.li-clipboard-paste:before {
+  content: '\e3eb';
+}
+.li-clipboard-pen-line:before {
+  content: '\e307';
+}
+.li-clipboard-pen:before {
+  content: '\e306';
+}
+.li-clipboard-plus:before {
+  content: '\e5c3';
+}
+.li-clipboard-type:before {
+  content: '\e308';
+}
+.li-clipboard-x:before {
+  content: '\e221';
+}
+.li-clipboard:before {
+  content: '\e089';
+}
+.li-clock-1:before {
+  content: '\e24a';
+}
+.li-clock-10:before {
+  content: '\e24b';
+}
+.li-clock-11:before {
+  content: '\e24c';
+}
+.li-clock-12:before {
+  content: '\e24d';
+}
+.li-clock-2:before {
+  content: '\e24e';
+}
+.li-clock-3:before {
+  content: '\e24f';
+}
+.li-clock-4:before {
+  content: '\e250';
+}
+.li-clock-5:before {
+  content: '\e251';
+}
+.li-clock-6:before {
+  content: '\e252';
+}
+.li-clock-7:before {
+  content: '\e253';
+}
+.li-clock-8:before {
+  content: '\e254';
+}
+.li-clock-9:before {
+  content: '\e255';
+}
+.li-clock-alert:before {
+  content: '\e62e';
+}
+.li-clock-arrow-down:before {
+  content: '\e604';
+}
+.li-clock-arrow-up:before {
+  content: '\e605';
+}
+.li-clock:before {
+  content: '\e08b';
+}
+.li-cloud-alert:before {
+  content: '\e637';
+}
+.li-cloud-cog:before {
+  content: '\e309';
+}
+.li-cloud-download:before {
+  content: '\e08d';
+}
+.li-cloud-drizzle:before {
+  content: '\e08e';
+}
+.li-cloud-fog:before {
+  content: '\e213';
+}
+.li-cloud-hail:before {
+  content: '\e08f';
+}
+.li-cloud-lightning:before {
+  content: '\e090';
+}
+.li-cloud-moon-rain:before {
+  content: '\e2f9';
+}
+.li-cloud-moon:before {
+  content: '\e214';
+}
+.li-cloud-off:before {
+  content: '\e091';
+}
+.li-cloud-rain-wind:before {
+  content: '\e093';
+}
+.li-cloud-rain:before {
+  content: '\e092';
+}
+.li-cloud-snow:before {
+  content: '\e094';
+}
+.li-cloud-sun-rain:before {
+  content: '\e2fa';
+}
+.li-cloud-sun:before {
+  content: '\e215';
+}
+.li-cloud-upload:before {
+  content: '\e095';
+}
+.li-cloud:before {
+  content: '\e08c';
+}
+.li-cloudy:before {
+  content: '\e216';
+}
+.li-clover:before {
+  content: '\e096';
+}
+.li-club:before {
+  content: '\e49a';
+}
+.li-code-xml:before {
+  content: '\e205';
+}
+.li-code:before {
+  content: '\e097';
+}
+.li-codepen:before {
+  content: '\e098';
+}
+.li-codesandbox:before {
+  content: '\e099';
+}
+.li-coffee:before {
+  content: '\e09a';
+}
+.li-cog:before {
+  content: '\e30a';
+}
+.li-coins:before {
+  content: '\e09b';
+}
+.li-columns-2:before {
+  content: '\e09c';
+}
+.li-columns-3:before {
+  content: '\e09d';
+}
+.li-columns-4:before {
+  content: '\e58d';
+}
+.li-combine:before {
+  content: '\e450';
+}
+.li-command:before {
+  content: '\e09e';
+}
+.li-compass:before {
+  content: '\e09f';
+}
+.li-component:before {
+  content: '\e2ac';
+}
+.li-computer:before {
+  content: '\e4e8';
+}
+.li-concierge-bell:before {
+  content: '\e37b';
+}
+.li-cone:before {
+  content: '\e527';
+}
+.li-construction:before {
+  content: '\e3b7';
+}
+.li-contact-round:before {
+  content: '\e467';
+}
+.li-contact:before {
+  content: '\e0a0';
+}
+.li-container:before {
+  content: '\e4d9';
+}
+.li-contrast:before {
+  content: '\e0a1';
+}
+.li-cookie:before {
+  content: '\e26a';
+}
+.li-cooking-pot:before {
+  content: '\e588';
+}
+.li-copy-check:before {
+  content: '\e3ff';
+}
+.li-copy-minus:before {
+  content: '\e400';
+}
+.li-copy-plus:before {
+  content: '\e401';
+}
+.li-copy-slash:before {
+  content: '\e402';
+}
+.li-copy-x:before {
+  content: '\e403';
+}
+.li-copy:before {
+  content: '\e0a2';
+}
+.li-copyleft:before {
+  content: '\e0a3';
+}
+.li-copyright:before {
+  content: '\e0a4';
+}
+.li-corner-down-left:before {
+  content: '\e0a5';
+}
+.li-corner-down-right:before {
+  content: '\e0a6';
+}
+.li-corner-left-down:before {
+  content: '\e0a7';
+}
+.li-corner-left-up:before {
+  content: '\e0a8';
+}
+.li-corner-right-down:before {
+  content: '\e0a9';
+}
+.li-corner-right-up:before {
+  content: '\e0aa';
+}
+.li-corner-up-left:before {
+  content: '\e0ab';
+}
+.li-corner-up-right:before {
+  content: '\e0ac';
+}
+.li-cpu:before {
+  content: '\e0ad';
+}
+.li-creative-commons:before {
+  content: '\e3b5';
+}
+.li-credit-card:before {
+  content: '\e0ae';
+}
+.li-croissant:before {
+  content: '\e2ad';
+}
+.li-crop:before {
+  content: '\e0af';
+}
+.li-cross:before {
+  content: '\e1e4';
+}
+.li-crosshair:before {
+  content: '\e0b0';
+}
+.li-crown:before {
+  content: '\e1d5';
+}
+.li-cuboid:before {
+  content: '\e528';
+}
+.li-cup-soda:before {
+  content: '\e2d0';
+}
+.li-currency:before {
+  content: '\e22f';
+}
+.li-cylinder:before {
+  content: '\e529';
+}
+.li-dam:before {
+  content: '\e60a';
+}
+.li-database-backup:before {
+  content: '\e3ae';
+}
+.li-database-zap:before {
+  content: '\e50f';
+}
+.li-database:before {
+  content: '\e0b1';
+}
+.li-delete:before {
+  content: '\e0b2';
+}
+.li-dessert:before {
+  content: '\e4bf';
+}
+.li-diameter:before {
+  content: '\e52a';
+}
+.li-diamond-minus:before {
+  content: '\e5e5';
+}
+.li-diamond-percent:before {
+  content: '\e51f';
+}
+.li-diamond-plus:before {
+  content: '\e5e6';
+}
+.li-diamond:before {
+  content: '\e2d1';
+}
+.li-dice-1:before {
+  content: '\e286';
+}
+.li-dice-2:before {
+  content: '\e287';
+}
+.li-dice-3:before {
+  content: '\e288';
+}
+.li-dice-4:before {
+  content: '\e289';
+}
+.li-dice-5:before {
+  content: '\e28a';
+}
+.li-dice-6:before {
+  content: '\e28b';
+}
+.li-dices:before {
+  content: '\e2c4';
+}
+.li-diff:before {
+  content: '\e30b';
+}
+.li-disc-2:before {
+  content: '\e3fa';
+}
+.li-disc-3:before {
+  content: '\e498';
+}
+.li-disc-album:before {
+  content: '\e560';
+}
+.li-disc:before {
+  content: '\e0b3';
+}
+.li-divide:before {
+  content: '\e0b4';
+}
+.li-dna-off:before {
+  content: '\e397';
+}
+.li-dna:before {
+  content: '\e396';
+}
+.li-dock:before {
+  content: '\e5d7';
+}
+.li-dog:before {
+  content: '\e390';
+}
+.li-dollar-sign:before {
+  content: '\e0b5';
+}
+.li-donut:before {
+  content: '\e4c0';
+}
+.li-door-closed:before {
+  content: '\e3d8';
+}
+.li-door-open:before {
+  content: '\e3d9';
+}
+.li-dot:before {
+  content: '\e453';
+}
+.li-download:before {
+  content: '\e0b6';
+}
+.li-drafting-compass:before {
+  content: '\e52b';
+}
+.li-drama:before {
+  content: '\e525';
+}
+.li-dribbble:before {
+  content: '\e0b7';
+}
+.li-drill:before {
+  content: '\e591';
+}
+.li-droplet-off:before {
+  content: '\e63c';
+}
+.li-droplet:before {
+  content: '\e0b8';
+}
+.li-droplets:before {
+  content: '\e0b9';
+}
+.li-drum:before {
+  content: '\e561';
+}
+.li-drumstick:before {
+  content: '\e25a';
+}
+.li-dumbbell:before {
+  content: '\e3a4';
+}
+.li-ear-off:before {
+  content: '\e386';
+}
+.li-ear:before {
+  content: '\e385';
+}
+.li-earth-lock:before {
+  content: '\e5d0';
+}
+.li-earth:before {
+  content: '\e1f2';
+}
+.li-eclipse:before {
+  content: '\e5a1';
+}
+.li-egg-fried:before {
+  content: '\e354';
+}
+.li-egg-off:before {
+  content: '\e398';
+}
+.li-egg:before {
+  content: '\e25c';
+}
+.li-ellipsis-vertical:before {
+  content: '\e0bb';
+}
+.li-ellipsis:before {
+  content: '\e0ba';
+}
+.li-equal-approximately:before {
+  content: '\e638';
+}
+.li-equal-not:before {
+  content: '\e1bd';
+}
+.li-equal:before {
+  content: '\e1bc';
+}
+.li-eraser:before {
+  content: '\e28e';
+}
+.li-ethernet-port:before {
+  content: '\e624';
+}
+.li-euro:before {
+  content: '\e0bc';
+}
+.li-expand:before {
+  content: '\e219';
+}
+.li-external-link:before {
+  content: '\e0bd';
+}
+.li-eye-closed:before {
+  content: '\e632';
+}
+.li-eye-off:before {
+  content: '\e0bf';
+}
+.li-eye:before {
+  content: '\e0be';
+}
+.li-facebook:before {
+  content: '\e0c0';
+}
+.li-factory:before {
+  content: '\e29e';
+}
+.li-fan:before {
+  content: '\e37c';
+}
+.li-fast-forward:before {
+  content: '\e0c1';
+}
+.li-feather:before {
+  content: '\e0c2';
+}
+.li-fence:before {
+  content: '\e586';
+}
+.li-ferris-wheel:before {
+  content: '\e483';
+}
+.li-figma:before {
+  content: '\e0c3';
+}
+.li-file-archive:before {
+  content: '\e30c';
+}
+.li-file-audio-2:before {
+  content: '\e30e';
+}
+.li-file-audio:before {
+  content: '\e30d';
+}
+.li-file-axis-3d:before {
+  content: '\e30f';
+}
+.li-file-badge-2:before {
+  content: '\e311';
+}
+.li-file-badge:before {
+  content: '\e310';
+}
+.li-file-box:before {
+  content: '\e312';
+}
+.li-file-chart-column-increasing:before {
+  content: '\e314';
+}
+.li-file-chart-column:before {
+  content: '\e313';
+}
+.li-file-chart-line:before {
+  content: '\e315';
+}
+.li-file-chart-pie:before {
+  content: '\e316';
+}
+.li-file-check-2:before {
+  content: '\e0c6';
+}
+.li-file-check:before {
+  content: '\e0c5';
+}
+.li-file-clock:before {
+  content: '\e317';
+}
+.li-file-code-2:before {
+  content: '\e462';
+}
+.li-file-code:before {
+  content: '\e0c7';
+}
+.li-file-cog:before {
+  content: '\e318';
+}
+.li-file-diff:before {
+  content: '\e319';
+}
+.li-file-digit:before {
+  content: '\e0c8';
+}
+.li-file-down:before {
+  content: '\e31a';
+}
+.li-file-heart:before {
+  content: '\e31b';
+}
+.li-file-image:before {
+  content: '\e31c';
+}
+.li-file-input:before {
+  content: '\e0c9';
+}
+.li-file-json-2:before {
+  content: '\e36f';
+}
+.li-file-json:before {
+  content: '\e36e';
+}
+.li-file-key-2:before {
+  content: '\e31e';
+}
+.li-file-key:before {
+  content: '\e31d';
+}
+.li-file-lock-2:before {
+  content: '\e320';
+}
+.li-file-lock:before {
+  content: '\e31f';
+}
+.li-file-minus-2:before {
+  content: '\e0cb';
+}
+.li-file-minus:before {
+  content: '\e0ca';
+}
+.li-file-music:before {
+  content: '\e562';
+}
+.li-file-output:before {
+  content: '\e0cc';
+}
+.li-file-pen-line:before {
+  content: '\e322';
+}
+.li-file-pen:before {
+  content: '\e321';
+}
+.li-file-plus-2:before {
+  content: '\e0ce';
+}
+.li-file-plus:before {
+  content: '\e0cd';
+}
+.li-file-question:before {
+  content: '\e323';
+}
+.li-file-scan:before {
+  content: '\e324';
+}
+.li-file-search-2:before {
+  content: '\e325';
+}
+.li-file-search:before {
+  content: '\e0cf';
+}
+.li-file-sliders:before {
+  content: '\e5a4';
+}
+.li-file-spreadsheet:before {
+  content: '\e326';
+}
+.li-file-stack:before {
+  content: '\e4a5';
+}
+.li-file-symlink:before {
+  content: '\e327';
+}
+.li-file-terminal:before {
+  content: '\e328';
+}
+.li-file-text:before {
+  content: '\e0d0';
+}
+.li-file-type-2:before {
+  content: '\e370';
+}
+.li-file-type:before {
+  content: '\e329';
+}
+.li-file-up:before {
+  content: '\e32a';
+}
+.li-file-user:before {
+  content: '\e631';
+}
+.li-file-video-2:before {
+  content: '\e32c';
+}
+.li-file-video:before {
+  content: '\e32b';
+}
+.li-file-volume-2:before {
+  content: '\e32e';
+}
+.li-file-volume:before {
+  content: '\e32d';
+}
+.li-file-warning:before {
+  content: '\e32f';
+}
+.li-file-x-2:before {
+  content: '\e0d2';
+}
+.li-file-x:before {
+  content: '\e0d1';
+}
+.li-file:before {
+  content: '\e0c4';
+}
+.li-files:before {
+  content: '\e0d3';
+}
+.li-film:before {
+  content: '\e0d4';
+}
+.li-filter-x:before {
+  content: '\e3b8';
+}
+.li-filter:before {
+  content: '\e0d5';
+}
+.li-fingerprint:before {
+  content: '\e2ca';
+}
+.li-fire-extinguisher:before {
+  content: '\e582';
+}
+.li-fish-off:before {
+  content: '\e3b3';
+}
+.li-fish-symbol:before {
+  content: '\e4f8';
+}
+.li-fish:before {
+  content: '\e3a9';
+}
+.li-flag-off:before {
+  content: '\e291';
+}
+.li-flag-triangle-left:before {
+  content: '\e236';
+}
+.li-flag-triangle-right:before {
+  content: '\e237';
+}
+.li-flag:before {
+  content: '\e0d6';
+}
+.li-flame-kindling:before {
+  content: '\e53e';
+}
+.li-flame:before {
+  content: '\e0d7';
+}
+.li-flashlight-off:before {
+  content: '\e0d9';
+}
+.li-flashlight:before {
+  content: '\e0d8';
+}
+.li-flask-conical-off:before {
+  content: '\e399';
+}
+.li-flask-conical:before {
+  content: '\e0da';
+}
+.li-flask-round:before {
+  content: '\e0db';
+}
+.li-flip-horizontal-2:before {
+  content: '\e361';
+}
+.li-flip-horizontal:before {
+  content: '\e360';
+}
+.li-flip-vertical-2:before {
+  content: '\e363';
+}
+.li-flip-vertical:before {
+  content: '\e362';
+}
+.li-flower-2:before {
+  content: '\e2d3';
+}
+.li-flower:before {
+  content: '\e2d2';
+}
+.li-focus:before {
+  content: '\e29d';
+}
+.li-fold-horizontal:before {
+  content: '\e43f';
+}
+.li-fold-vertical:before {
+  content: '\e440';
+}
+.li-folder-archive:before {
+  content: '\e330';
+}
+.li-folder-check:before {
+  content: '\e331';
+}
+.li-folder-clock:before {
+  content: '\e332';
+}
+.li-folder-closed:before {
+  content: '\e333';
+}
+.li-folder-code:before {
+  content: '\e5ff';
+}
+.li-folder-cog:before {
+  content: '\e334';
+}
+.li-folder-dot:before {
+  content: '\e4c9';
+}
+.li-folder-down:before {
+  content: '\e335';
+}
+.li-folder-git-2:before {
+  content: '\e40e';
+}
+.li-folder-git:before {
+  content: '\e40d';
+}
+.li-folder-heart:before {
+  content: '\e336';
+}
+.li-folder-input:before {
+  content: '\e337';
+}
+.li-folder-kanban:before {
+  content: '\e4ca';
+}
+.li-folder-key:before {
+  content: '\e338';
+}
+.li-folder-lock:before {
+  content: '\e339';
+}
+.li-folder-minus:before {
+  content: '\e0dd';
+}
+.li-folder-open-dot:before {
+  content: '\e4cb';
+}
+.li-folder-open:before {
+  content: '\e246';
+}
+.li-folder-output:before {
+  content: '\e33a';
+}
+.li-folder-pen:before {
+  content: '\e33b';
+}
+.li-folder-plus:before {
+  content: '\e0de';
+}
+.li-folder-root:before {
+  content: '\e4cc';
+}
+.li-folder-search-2:before {
+  content: '\e33d';
+}
+.li-folder-search:before {
+  content: '\e33c';
+}
+.li-folder-symlink:before {
+  content: '\e33e';
+}
+.li-folder-sync:before {
+  content: '\e4cd';
+}
+.li-folder-tree:before {
+  content: '\e33f';
+}
+.li-folder-up:before {
+  content: '\e340';
+}
+.li-folder-x:before {
+  content: '\e341';
+}
+.li-folder:before {
+  content: '\e0dc';
+}
+.li-folders:before {
+  content: '\e342';
+}
+.li-footprints:before {
+  content: '\e3bc';
+}
+.li-forklift:before {
+  content: '\e3c4';
+}
+.li-forward:before {
+  content: '\e228';
+}
+.li-frame:before {
+  content: '\e290';
+}
+.li-framer:before {
+  content: '\e0df';
+}
+.li-frown:before {
+  content: '\e0e0';
+}
+.li-fuel:before {
+  content: '\e2ae';
+}
+.li-fullscreen:before {
+  content: '\e538';
+}
+.li-gallery-horizontal-end:before {
+  content: '\e4d3';
+}
+.li-gallery-horizontal:before {
+  content: '\e4d2';
+}
+.li-gallery-thumbnails:before {
+  content: '\e4d4';
+}
+.li-gallery-vertical-end:before {
+  content: '\e4d6';
+}
+.li-gallery-vertical:before {
+  content: '\e4d5';
+}
+.li-gamepad-2:before {
+  content: '\e0e2';
+}
+.li-gamepad:before {
+  content: '\e0e1';
+}
+.li-gauge:before {
+  content: '\e1be';
+}
+.li-gavel:before {
+  content: '\e0e3';
+}
+.li-gem:before {
+  content: '\e241';
+}
+.li-ghost:before {
+  content: '\e20d';
+}
+.li-gift:before {
+  content: '\e0e4';
+}
+.li-git-branch-plus:before {
+  content: '\e1f3';
+}
+.li-git-branch:before {
+  content: '\e0e5';
+}
+.li-git-commit-horizontal:before {
+  content: '\e0e6';
+}
+.li-git-commit-vertical:before {
+  content: '\e556';
+}
+.li-git-compare-arrows:before {
+  content: '\e557';
+}
+.li-git-compare:before {
+  content: '\e35c';
+}
+.li-git-fork:before {
+  content: '\e28c';
+}
+.li-git-graph:before {
+  content: '\e558';
+}
+.li-git-merge:before {
+  content: '\e0e7';
+}
+.li-git-pull-request-arrow:before {
+  content: '\e559';
+}
+.li-git-pull-request-closed:before {
+  content: '\e35d';
+}
+.li-git-pull-request-create-arrow:before {
+  content: '\e55b';
+}
+.li-git-pull-request-create:before {
+  content: '\e55a';
+}
+.li-git-pull-request-draft:before {
+  content: '\e35e';
+}
+.li-git-pull-request:before {
+  content: '\e0e8';
+}
+.li-github:before {
+  content: '\e0e9';
+}
+.li-gitlab:before {
+  content: '\e0ea';
+}
+.li-glass-water:before {
+  content: '\e2d4';
+}
+.li-glasses:before {
+  content: '\e20c';
+}
+.li-globe-lock:before {
+  content: '\e5d1';
+}
+.li-globe:before {
+  content: '\e0eb';
+}
+.li-goal:before {
+  content: '\e4a9';
+}
+.li-grab:before {
+  content: '\e1e5';
+}
+.li-graduation-cap:before {
+  content: '\e233';
+}
+.li-grape:before {
+  content: '\e355';
+}
+.li-grid-2x2-check:before {
+  content: '\e5e8';
+}
+.li-grid-2x2-plus:before {
+  content: '\e62c';
+}
+.li-grid-2x2-x:before {
+  content: '\e5e9';
+}
+.li-grid-2x2:before {
+  content: '\e503';
+}
+.li-grid-3x3:before {
+  content: '\e0ec';
+}
+.li-grip-horizontal:before {
+  content: '\e0ed';
+}
+.li-grip-vertical:before {
+  content: '\e0ee';
+}
+.li-grip:before {
+  content: '\e3b4';
+}
+.li-group:before {
+  content: '\e468';
+}
+.li-guitar:before {
+  content: '\e563';
+}
+.li-ham:before {
+  content: '\e5db';
+}
+.li-hammer:before {
+  content: '\e0ef';
+}
+.li-hand-coins:before {
+  content: '\e5bc';
+}
+.li-hand-heart:before {
+  content: '\e5bd';
+}
+.li-hand-helping:before {
+  content: '\e3bb';
+}
+.li-hand-metal:before {
+  content: '\e22b';
+}
+.li-hand-platter:before {
+  content: '\e5be';
+}
+.li-hand:before {
+  content: '\e1d6';
+}
+.li-handshake:before {
+  content: '\e5c4';
+}
+.li-hard-drive-download:before {
+  content: '\e4e9';
+}
+.li-hard-drive-upload:before {
+  content: '\e4ea';
+}
+.li-hard-drive:before {
+  content: '\e0f0';
+}
+.li-hard-hat:before {
+  content: '\e0f1';
+}
+.li-hash:before {
+  content: '\e0f2';
+}
+.li-haze:before {
+  content: '\e0f3';
+}
+.li-hdmi-port:before {
+  content: '\e4eb';
+}
+.li-heading-1:before {
+  content: '\e388';
+}
+.li-heading-2:before {
+  content: '\e389';
+}
+.li-heading-3:before {
+  content: '\e38a';
+}
+.li-heading-4:before {
+  content: '\e38b';
+}
+.li-heading-5:before {
+  content: '\e38c';
+}
+.li-heading-6:before {
+  content: '\e38d';
+}
+.li-heading:before {
+  content: '\e387';
+}
+.li-headphone-off:before {
+  content: '\e62d';
+}
+.li-headphones:before {
+  content: '\e0f4';
+}
+.li-headset:before {
+  content: '\e5c1';
+}
+.li-heart-crack:before {
+  content: '\e2d5';
+}
+.li-heart-handshake:before {
+  content: '\e2d6';
+}
+.li-heart-off:before {
+  content: '\e294';
+}
+.li-heart-pulse:before {
+  content: '\e371';
+}
+.li-heart:before {
+  content: '\e0f5';
+}
+.li-heater:before {
+  content: '\e592';
+}
+.li-hexagon:before {
+  content: '\e0f6';
+}
+.li-highlighter:before {
+  content: '\e0f7';
+}
+.li-history:before {
+  content: '\e1f4';
+}
+.li-hop-off:before {
+  content: '\e39b';
+}
+.li-hop:before {
+  content: '\e39a';
+}
+.li-hospital:before {
+  content: '\e5dc';
+}
+.li-hotel:before {
+  content: '\e3e5';
+}
+.li-hourglass:before {
+  content: '\e295';
+}
+.li-house-plug:before {
+  content: '\e5f4';
+}
+.li-house-plus:before {
+  content: '\e5f5';
+}
+.li-house-wifi:before {
+  content: '\e640';
+}
+.li-house:before {
+  content: '\e0f8';
+}
+.li-ice-cream-bowl:before {
+  content: '\e3aa';
+}
+.li-ice-cream-cone:before {
+  content: '\e356';
+}
+.li-id-card:before {
+  content: '\e61b';
+}
+.li-image-down:before {
+  content: '\e540';
+}
+.li-image-minus:before {
+  content: '\e1f5';
+}
+.li-image-off:before {
+  content: '\e1bf';
+}
+.li-image-play:before {
+  content: '\e5e3';
+}
+.li-image-plus:before {
+  content: '\e1f6';
+}
+.li-image-up:before {
+  content: '\e5cf';
+}
+.li-image-upscale:before {
+  content: '\e63b';
+}
+.li-image:before {
+  content: '\e0f9';
+}
+.li-images:before {
+  content: '\e5c8';
+}
+.li-import:before {
+  content: '\e22e';
+}
+.li-inbox:before {
+  content: '\e0fa';
+}
+.li-indent-decrease:before {
+  content: '\e0fb';
+}
+.li-indent-increase:before {
+  content: '\e0fc';
+}
+.li-indian-rupee:before {
+  content: '\e0fd';
+}
+.li-infinity:before {
+  content: '\e1e6';
+}
+.li-info:before {
+  content: '\e0fe';
+}
+.li-inspection-panel:before {
+  content: '\e587';
+}
+.li-instagram:before {
+  content: '\e0ff';
+}
+.li-italic:before {
+  content: '\e100';
+}
+.li-iteration-ccw:before {
+  content: '\e427';
+}
+.li-iteration-cw:before {
+  content: '\e428';
+}
+.li-japanese-yen:before {
+  content: '\e101';
+}
+.li-joystick:before {
+  content: '\e358';
+}
+.li-kanban:before {
+  content: '\e4e0';
+}
+.li-key-round:before {
+  content: '\e4a7';
+}
+.li-key-square:before {
+  content: '\e4a8';
+}
+.li-key:before {
+  content: '\e102';
+}
+.li-keyboard-music:before {
+  content: '\e564';
+}
+.li-keyboard-off:before {
+  content: '\e5e2';
+}
+.li-keyboard:before {
+  content: '\e283';
+}
+.li-lamp-ceiling:before {
+  content: '\e2d8';
+}
+.li-lamp-desk:before {
+  content: '\e2d9';
+}
+.li-lamp-floor:before {
+  content: '\e2da';
+}
+.li-lamp-wall-down:before {
+  content: '\e2db';
+}
+.li-lamp-wall-up:before {
+  content: '\e2dc';
+}
+.li-lamp:before {
+  content: '\e2d7';
+}
+.li-land-plot:before {
+  content: '\e52c';
+}
+.li-landmark:before {
+  content: '\e239';
+}
+.li-languages:before {
+  content: '\e103';
+}
+.li-laptop-minimal-check:before {
+  content: '\e636';
+}
+.li-laptop-minimal:before {
+  content: '\e1d7';
+}
+.li-laptop:before {
+  content: '\e1cc';
+}
+.li-lasso-select:before {
+  content: '\e1ce';
+}
+.li-lasso:before {
+  content: '\e1cd';
+}
+.li-laugh:before {
+  content: '\e2ff';
+}
+.li-layers-2:before {
+  content: '\e52e';
+}
+.li-layers:before {
+  content: '\e52d';
+}
+.li-layout-dashboard:before {
+  content: '\e1c0';
+}
+.li-layout-grid:before {
+  content: '\e104';
+}
+.li-layout-list:before {
+  content: '\e1d8';
+}
+.li-layout-panel-left:before {
+  content: '\e474';
+}
+.li-layout-panel-top:before {
+  content: '\e475';
+}
+.li-layout-template:before {
+  content: '\e206';
+}
+.li-leaf:before {
+  content: '\e2dd';
+}
+.li-leafy-green:before {
+  content: '\e473';
+}
+.li-lectern:before {
+  content: '\e5ed';
+}
+.li-letter-text:before {
+  content: '\e609';
+}
+.li-library-big:before {
+  content: '\e552';
+}
+.li-library:before {
+  content: '\e105';
+}
+.li-life-buoy:before {
+  content: '\e106';
+}
+.li-ligature:before {
+  content: '\e43e';
+}
+.li-lightbulb-off:before {
+  content: '\e207';
+}
+.li-lightbulb:before {
+  content: '\e1c1';
+}
+.li-link-2-off:before {
+  content: '\e109';
+}
+.li-link-2:before {
+  content: '\e108';
+}
+.li-link:before {
+  content: '\e107';
+}
+.li-linkedin:before {
+  content: '\e10a';
+}
+.li-list-check:before {
+  content: '\e5fe';
+}
+.li-list-checks:before {
+  content: '\e1cf';
+}
+.li-list-collapse:before {
+  content: '\e59f';
+}
+.li-list-end:before {
+  content: '\e2de';
+}
+.li-list-filter-plus:before {
+  content: '\e63d';
+}
+.li-list-filter:before {
+  content: '\e464';
+}
+.li-list-minus:before {
+  content: '\e23d';
+}
+.li-list-music:before {
+  content: '\e2df';
+}
+.li-list-ordered:before {
+  content: '\e1d0';
+}
+.li-list-plus:before {
+  content: '\e23e';
+}
+.li-list-restart:before {
+  content: '\e456';
+}
+.li-list-start:before {
+  content: '\e2e0';
+}
+.li-list-todo:before {
+  content: '\e4c7';
+}
+.li-list-tree:before {
+  content: '\e40c';
+}
+.li-list-video:before {
+  content: '\e2e1';
+}
+.li-list-x:before {
+  content: '\e23f';
+}
+.li-list:before {
+  content: '\e10b';
+}
+.li-loader-circle:before {
+  content: '\e10d';
+}
+.li-loader-pinwheel:before {
+  content: '\e5ea';
+}
+.li-loader:before {
+  content: '\e10c';
+}
+.li-locate-fixed:before {
+  content: '\e1da';
+}
+.li-locate-off:before {
+  content: '\e281';
+}
+.li-locate:before {
+  content: '\e1d9';
+}
+.li-lock-keyhole-open:before {
+  content: '\e536';
+}
+.li-lock-keyhole:before {
+  content: '\e535';
+}
+.li-lock-open:before {
+  content: '\e10f';
+}
+.li-lock:before {
+  content: '\e10e';
+}
+.li-log-in:before {
+  content: '\e110';
+}
+.li-log-out:before {
+  content: '\e111';
+}
+.li-logs:before {
+  content: '\e5f8';
+}
+.li-lollipop:before {
+  content: '\e4c1';
+}
+.li-luggage:before {
+  content: '\e2c9';
+}
+.li-magnet:before {
+  content: '\e2b4';
+}
+.li-mail-check:before {
+  content: '\e364';
+}
+.li-mail-minus:before {
+  content: '\e365';
+}
+.li-mail-open:before {
+  content: '\e366';
+}
+.li-mail-plus:before {
+  content: '\e367';
+}
+.li-mail-question:before {
+  content: '\e368';
+}
+.li-mail-search:before {
+  content: '\e369';
+}
+.li-mail-warning:before {
+  content: '\e36a';
+}
+.li-mail-x:before {
+  content: '\e36b';
+}
+.li-mail:before {
+  content: '\e112';
+}
+.li-mailbox:before {
+  content: '\e3d7';
+}
+.li-mails:before {
+  content: '\e36c';
+}
+.li-map-pin-check-inside:before {
+  content: '\e614';
+}
+.li-map-pin-check:before {
+  content: '\e613';
+}
+.li-map-pin-house:before {
+  content: '\e620';
+}
+.li-map-pin-minus-inside:before {
+  content: '\e616';
+}
+.li-map-pin-minus:before {
+  content: '\e615';
+}
+.li-map-pin-off:before {
+  content: '\e2a5';
+}
+.li-map-pin-plus-inside:before {
+  content: '\e618';
+}
+.li-map-pin-plus:before {
+  content: '\e617';
+}
+.li-map-pin-x-inside:before {
+  content: '\e61a';
+}
+.li-map-pin-x:before {
+  content: '\e619';
+}
+.li-map-pin:before {
+  content: '\e114';
+}
+.li-map-pinned:before {
+  content: '\e541';
+}
+.li-map-plus:before {
+  content: '\e643';
+}
+.li-map:before {
+  content: '\e113';
+}
+.li-martini:before {
+  content: '\e2e2';
+}
+.li-maximize-2:before {
+  content: '\e116';
+}
+.li-maximize:before {
+  content: '\e115';
+}
+.li-medal:before {
+  content: '\e372';
+}
+.li-megaphone-off:before {
+  content: '\e373';
+}
+.li-megaphone:before {
+  content: '\e234';
+}
+.li-meh:before {
+  content: '\e117';
+}
+.li-memory-stick:before {
+  content: '\e449';
+}
+.li-menu:before {
+  content: '\e118';
+}
+.li-merge:before {
+  content: '\e443';
+}
+.li-message-circle-code:before {
+  content: '\e566';
+}
+.li-message-circle-dashed:before {
+  content: '\e567';
+}
+.li-message-circle-heart:before {
+  content: '\e568';
+}
+.li-message-circle-more:before {
+  content: '\e569';
+}
+.li-message-circle-off:before {
+  content: '\e56a';
+}
+.li-message-circle-plus:before {
+  content: '\e56b';
+}
+.li-message-circle-question:before {
+  content: '\e56c';
+}
+.li-message-circle-reply:before {
+  content: '\e56d';
+}
+.li-message-circle-warning:before {
+  content: '\e56e';
+}
+.li-message-circle-x:before {
+  content: '\e56f';
+}
+.li-message-circle:before {
+  content: '\e119';
+}
+.li-message-square-code:before {
+  content: '\e570';
+}
+.li-message-square-dashed:before {
+  content: '\e40f';
+}
+.li-message-square-diff:before {
+  content: '\e571';
+}
+.li-message-square-dot:before {
+  content: '\e572';
+}
+.li-message-square-heart:before {
+  content: '\e573';
+}
+.li-message-square-lock:before {
+  content: '\e630';
+}
+.li-message-square-more:before {
+  content: '\e574';
+}
+.li-message-square-off:before {
+  content: '\e575';
+}
+.li-message-square-plus:before {
+  content: '\e410';
+}
+.li-message-square-quote:before {
+  content: '\e576';
+}
+.li-message-square-reply:before {
+  content: '\e577';
+}
+.li-message-square-share:before {
+  content: '\e578';
+}
+.li-message-square-text:before {
+  content: '\e579';
+}
+.li-message-square-warning:before {
+  content: '\e57a';
+}
+.li-message-square-x:before {
+  content: '\e57b';
+}
+.li-message-square:before {
+  content: '\e11a';
+}
+.li-messages-square:before {
+  content: '\e411';
+}
+.li-mic-off:before {
+  content: '\e11c';
+}
+.li-mic-vocal:before {
+  content: '\e34c';
+}
+.li-mic:before {
+  content: '\e11b';
+}
+.li-microchip:before {
+  content: '\e61e';
+}
+.li-microscope:before {
+  content: '\e2e3';
+}
+.li-microwave:before {
+  content: '\e37d';
+}
+.li-milestone:before {
+  content: '\e297';
+}
+.li-milk-off:before {
+  content: '\e39d';
+}
+.li-milk:before {
+  content: '\e39c';
+}
+.li-minimize-2:before {
+  content: '\e11e';
+}
+.li-minimize:before {
+  content: '\e11d';
+}
+.li-minus:before {
+  content: '\e11f';
+}
+.li-monitor-check:before {
+  content: '\e486';
+}
+.li-monitor-cog:before {
+  content: '\e607';
+}
+.li-monitor-dot:before {
+  content: '\e487';
+}
+.li-monitor-down:before {
+  content: '\e425';
+}
+.li-monitor-off:before {
+  content: '\e1db';
+}
+.li-monitor-pause:before {
+  content: '\e488';
+}
+.li-monitor-play:before {
+  content: '\e489';
+}
+.li-monitor-smartphone:before {
+  content: '\e3a5';
+}
+.li-monitor-speaker:before {
+  content: '\e20f';
+}
+.li-monitor-stop:before {
+  content: '\e48a';
+}
+.li-monitor-up:before {
+  content: '\e426';
+}
+.li-monitor-x:before {
+  content: '\e48b';
+}
+.li-monitor:before {
+  content: '\e120';
+}
+.li-moon-star:before {
+  content: '\e414';
+}
+.li-moon:before {
+  content: '\e121';
+}
+.li-mountain-snow:before {
+  content: '\e231';
+}
+.li-mountain:before {
+  content: '\e230';
+}
+.li-mouse-off:before {
+  content: '\e5df';
+}
+.li-mouse-pointer-2:before {
+  content: '\e1c2';
+}
+.li-mouse-pointer-ban:before {
+  content: '\e5eb';
+}
+.li-mouse-pointer-click:before {
+  content: '\e123';
+}
+.li-mouse-pointer:before {
+  content: '\e122';
+}
+.li-mouse:before {
+  content: '\e28d';
+}
+.li-move-3d:before {
+  content: '\e2e4';
+}
+.li-move-diagonal-2:before {
+  content: '\e1c4';
+}
+.li-move-diagonal:before {
+  content: '\e1c3';
+}
+.li-move-down-left:before {
+  content: '\e491';
+}
+.li-move-down-right:before {
+  content: '\e492';
+}
+.li-move-down:before {
+  content: '\e490';
+}
+.li-move-horizontal:before {
+  content: '\e1c5';
+}
+.li-move-left:before {
+  content: '\e493';
+}
+.li-move-right:before {
+  content: '\e494';
+}
+.li-move-up-left:before {
+  content: '\e496';
+}
+.li-move-up-right:before {
+  content: '\e497';
+}
+.li-move-up:before {
+  content: '\e495';
+}
+.li-move-vertical:before {
+  content: '\e1c6';
+}
+.li-move:before {
+  content: '\e124';
+}
+.li-music-2:before {
+  content: '\e34d';
+}
+.li-music-3:before {
+  content: '\e34e';
+}
+.li-music-4:before {
+  content: '\e34f';
+}
+.li-music:before {
+  content: '\e125';
+}
+.li-navigation-2-off:before {
+  content: '\e2a6';
+}
+.li-navigation-2:before {
+  content: '\e127';
+}
+.li-navigation-off:before {
+  content: '\e2a7';
+}
+.li-navigation:before {
+  content: '\e126';
+}
+.li-network:before {
+  content: '\e128';
+}
+.li-newspaper:before {
+  content: '\e34b';
+}
+.li-nfc:before {
+  content: '\e3c6';
+}
+.li-notebook-pen:before {
+  content: '\e59a';
+}
+.li-notebook-tabs:before {
+  content: '\e59b';
+}
+.li-notebook-text:before {
+  content: '\e59c';
+}
+.li-notebook:before {
+  content: '\e599';
+}
+.li-notepad-text-dashed:before {
+  content: '\e59e';
+}
+.li-notepad-text:before {
+  content: '\e59d';
+}
+.li-nut-off:before {
+  content: '\e39f';
+}
+.li-nut:before {
+  content: '\e39e';
+}
+.li-octagon-alert:before {
+  content: '\e12a';
+}
+.li-octagon-minus:before {
+  content: '\e62b';
+}
+.li-octagon-pause:before {
+  content: '\e21a';
+}
+.li-octagon-x:before {
+  content: '\e12b';
+}
+.li-octagon:before {
+  content: '\e129';
+}
+.li-omega:before {
+  content: '\e61d';
+}
+.li-option:before {
+  content: '\e1f7';
+}
+.li-orbit:before {
+  content: '\e3ea';
+}
+.li-origami:before {
+  content: '\e5e7';
+}
+.li-package-2:before {
+  content: '\e343';
+}
+.li-package-check:before {
+  content: '\e265';
+}
+.li-package-minus:before {
+  content: '\e266';
+}
+.li-package-open:before {
+  content: '\e2cb';
+}
+.li-package-plus:before {
+  content: '\e267';
+}
+.li-package-search:before {
+  content: '\e268';
+}
+.li-package-x:before {
+  content: '\e269';
+}
+.li-package:before {
+  content: '\e12c';
+}
+.li-paint-bucket:before {
+  content: '\e2e5';
+}
+.li-paint-roller:before {
+  content: '\e5a2';
+}
+.li-paintbrush-vertical:before {
+  content: '\e2e7';
+}
+.li-paintbrush:before {
+  content: '\e2e6';
+}
+.li-palette:before {
+  content: '\e1dc';
+}
+.li-panel-bottom-close:before {
+  content: '\e431';
+}
+.li-panel-bottom-dashed:before {
+  content: '\e432';
+}
+.li-panel-bottom-open:before {
+  content: '\e433';
+}
+.li-panel-bottom:before {
+  content: '\e430';
+}
+.li-panel-left-close:before {
+  content: '\e21b';
+}
+.li-panel-left-dashed:before {
+  content: '\e434';
+}
+.li-panel-left-open:before {
+  content: '\e21c';
+}
+.li-panel-left:before {
+  content: '\e12d';
+}
+.li-panel-right-close:before {
+  content: '\e436';
+}
+.li-panel-right-dashed:before {
+  content: '\e437';
+}
+.li-panel-right-open:before {
+  content: '\e438';
+}
+.li-panel-right:before {
+  content: '\e435';
+}
+.li-panel-top-close:before {
+  content: '\e43a';
+}
+.li-panel-top-dashed:before {
+  content: '\e43b';
+}
+.li-panel-top-open:before {
+  content: '\e43c';
+}
+.li-panel-top:before {
+  content: '\e439';
+}
+.li-panels-left-bottom:before {
+  content: '\e12e';
+}
+.li-panels-right-bottom:before {
+  content: '\e58c';
+}
+.li-panels-top-left:before {
+  content: '\e12f';
+}
+.li-paperclip:before {
+  content: '\e130';
+}
+.li-parentheses:before {
+  content: '\e448';
+}
+.li-parking-meter:before {
+  content: '\e504';
+}
+.li-party-popper:before {
+  content: '\e346';
+}
+.li-pause:before {
+  content: '\e131';
+}
+.li-paw-print:before {
+  content: '\e4f9';
+}
+.li-pc-case:before {
+  content: '\e44a';
+}
+.li-pen-line:before {
+  content: '\e133';
+}
+.li-pen-off:before {
+  content: '\e5f2';
+}
+.li-pen-tool:before {
+  content: '\e134';
+}
+.li-pen:before {
+  content: '\e132';
+}
+.li-pencil-line:before {
+  content: '\e4f4';
+}
+.li-pencil-off:before {
+  content: '\e5f3';
+}
+.li-pencil-ruler:before {
+  content: '\e4f5';
+}
+.li-pencil:before {
+  content: '\e1f8';
+}
+.li-pentagon:before {
+  content: '\e52f';
+}
+.li-percent:before {
+  content: '\e135';
+}
+.li-person-standing:before {
+  content: '\e21d';
+}
+.li-philippine-peso:before {
+  content: '\e608';
+}
+.li-phone-call:before {
+  content: '\e137';
+}
+.li-phone-forwarded:before {
+  content: '\e138';
+}
+.li-phone-incoming:before {
+  content: '\e139';
+}
+.li-phone-missed:before {
+  content: '\e13a';
+}
+.li-phone-off:before {
+  content: '\e13b';
+}
+.li-phone-outgoing:before {
+  content: '\e13c';
+}
+.li-phone:before {
+  content: '\e136';
+}
+.li-pi:before {
+  content: '\e476';
+}
+.li-piano:before {
+  content: '\e565';
+}
+.li-pickaxe:before {
+  content: '\e5ca';
+}
+.li-picture-in-picture-2:before {
+  content: '\e3b2';
+}
+.li-picture-in-picture:before {
+  content: '\e3b1';
+}
+.li-piggy-bank:before {
+  content: '\e13d';
+}
+.li-pilcrow-left:before {
+  content: '\e5e0';
+}
+.li-pilcrow-right:before {
+  content: '\e5e1';
+}
+.li-pilcrow:before {
+  content: '\e3a6';
+}
+.li-pill-bottle:before {
+  content: '\e5ee';
+}
+.li-pill:before {
+  content: '\e3c0';
+}
+.li-pin-off:before {
+  content: '\e2b5';
+}
+.li-pin:before {
+  content: '\e258';
+}
+.li-pipette:before {
+  content: '\e13e';
+}
+.li-pizza:before {
+  content: '\e357';
+}
+.li-plane-landing:before {
+  content: '\e3d0';
+}
+.li-plane-takeoff:before {
+  content: '\e3d1';
+}
+.li-plane:before {
+  content: '\e1dd';
+}
+.li-play:before {
+  content: '\e13f';
+}
+.li-plug-2:before {
+  content: '\e383';
+}
+.li-plug-zap:before {
+  content: '\e460';
+}
+.li-plug:before {
+  content: '\e382';
+}
+.li-plus:before {
+  content: '\e140';
+}
+.li-pocket-knife:before {
+  content: '\e4a4';
+}
+.li-pocket:before {
+  content: '\e141';
+}
+.li-podcast:before {
+  content: '\e1f9';
+}
+.li-pointer-off:before {
+  content: '\e583';
+}
+.li-pointer:before {
+  content: '\e1e7';
+}
+.li-popcorn:before {
+  content: '\e4c2';
+}
+.li-popsicle:before {
+  content: '\e4c3';
+}
+.li-pound-sterling:before {
+  content: '\e142';
+}
+.li-power-off:before {
+  content: '\e208';
+}
+.li-power:before {
+  content: '\e143';
+}
+.li-presentation:before {
+  content: '\e4b2';
+}
+.li-printer-check:before {
+  content: '\e5f9';
+}
+.li-printer:before {
+  content: '\e144';
+}
+.li-projector:before {
+  content: '\e4b3';
+}
+.li-proportions:before {
+  content: '\e5d3';
+}
+.li-puzzle:before {
+  content: '\e29b';
+}
+.li-pyramid:before {
+  content: '\e530';
+}
+.li-qr-code:before {
+  content: '\e1de';
+}
+.li-quote:before {
+  content: '\e238';
+}
+.li-rabbit:before {
+  content: '\e4fa';
+}
+.li-radar:before {
+  content: '\e49b';
+}
+.li-radiation:before {
+  content: '\e446';
+}
+.li-radical:before {
+  content: '\e5c6';
+}
+.li-radio-receiver:before {
+  content: '\e1fa';
+}
+.li-radio-tower:before {
+  content: '\e408';
+}
+.li-radio:before {
+  content: '\e145';
+}
+.li-radius:before {
+  content: '\e531';
+}
+.li-rail-symbol:before {
+  content: '\e505';
+}
+.li-rainbow:before {
+  content: '\e4c6';
+}
+.li-rat:before {
+  content: '\e3ef';
+}
+.li-ratio:before {
+  content: '\e4ec';
+}
+.li-receipt-cent:before {
+  content: '\e5a9';
+}
+.li-receipt-euro:before {
+  content: '\e5aa';
+}
+.li-receipt-indian-rupee:before {
+  content: '\e5ab';
+}
+.li-receipt-japanese-yen:before {
+  content: '\e5ac';
+}
+.li-receipt-pound-sterling:before {
+  content: '\e5ad';
+}
+.li-receipt-russian-ruble:before {
+  content: '\e5ae';
+}
+.li-receipt-swiss-franc:before {
+  content: '\e5af';
+}
+.li-receipt-text:before {
+  content: '\e5b0';
+}
+.li-receipt:before {
+  content: '\e3d6';
+}
+.li-rectangle-ellipsis:before {
+  content: '\e21e';
+}
+.li-rectangle-horizontal:before {
+  content: '\e379';
+}
+.li-rectangle-vertical:before {
+  content: '\e37a';
+}
+.li-recycle:before {
+  content: '\e2e8';
+}
+.li-redo-2:before {
+  content: '\e29f';
+}
+.li-redo-dot:before {
+  content: '\e454';
+}
+.li-redo:before {
+  content: '\e146';
+}
+.li-refresh-ccw-dot:before {
+  content: '\e4b6';
+}
+.li-refresh-ccw:before {
+  content: '\e147';
+}
+.li-refresh-cw-off:before {
+  content: '\e49c';
+}
+.li-refresh-cw:before {
+  content: '\e148';
+}
+.li-refrigerator:before {
+  content: '\e37e';
+}
+.li-regex:before {
+  content: '\e1fb';
+}
+.li-remove-formatting:before {
+  content: '\e3b6';
+}
+.li-repeat-1:before {
+  content: '\e1fc';
+}
+.li-repeat-2:before {
+  content: '\e415';
+}
+.li-repeat:before {
+  content: '\e149';
+}
+.li-replace-all:before {
+  content: '\e3df';
+}
+.li-replace:before {
+  content: '\e3de';
+}
+.li-reply-all:before {
+  content: '\e22a';
+}
+.li-reply:before {
+  content: '\e229';
+}
+.li-rewind:before {
+  content: '\e14a';
+}
+.li-ribbon:before {
+  content: '\e55c';
+}
+.li-rocket:before {
+  content: '\e285';
+}
+.li-rocking-chair:before {
+  content: '\e232';
+}
+.li-roller-coaster:before {
+  content: '\e484';
+}
+.li-rotate-3d:before {
+  content: '\e2e9';
+}
+.li-rotate-ccw-square:before {
+  content: '\e5d4';
+}
+.li-rotate-ccw:before {
+  content: '\e14b';
+}
+.li-rotate-cw-square:before {
+  content: '\e5d5';
+}
+.li-rotate-cw:before {
+  content: '\e14c';
+}
+.li-route-off:before {
+  content: '\e543';
+}
+.li-route:before {
+  content: '\e542';
+}
+.li-router:before {
+  content: '\e3c2';
+}
+.li-rows-2:before {
+  content: '\e43d';
+}
+.li-rows-3:before {
+  content: '\e58e';
+}
+.li-rows-4:before {
+  content: '\e58f';
+}
+.li-rss:before {
+  content: '\e14d';
+}
+.li-ruler:before {
+  content: '\e14e';
+}
+.li-russian-ruble:before {
+  content: '\e14f';
+}
+.li-sailboat:before {
+  content: '\e381';
+}
+.li-salad:before {
+  content: '\e3ab';
+}
+.li-sandwich:before {
+  content: '\e3ac';
+}
+.li-satellite-dish:before {
+  content: '\e44c';
+}
+.li-satellite:before {
+  content: '\e44b';
+}
+.li-save-all:before {
+  content: '\e413';
+}
+.li-save-off:before {
+  content: '\e5f7';
+}
+.li-save:before {
+  content: '\e150';
+}
+.li-scale-3d:before {
+  content: '\e2ea';
+}
+.li-scale:before {
+  content: '\e211';
+}
+.li-scaling:before {
+  content: '\e2eb';
+}
+.li-scan-barcode:before {
+  content: '\e539';
+}
+.li-scan-eye:before {
+  content: '\e53a';
+}
+.li-scan-face:before {
+  content: '\e374';
+}
+.li-scan-heart:before {
+  content: '\e63e';
+}
+.li-scan-line:before {
+  content: '\e257';
+}
+.li-scan-qr-code:before {
+  content: '\e5fa';
+}
+.li-scan-search:before {
+  content: '\e53b';
+}
+.li-scan-text:before {
+  content: '\e53c';
+}
+.li-scan:before {
+  content: '\e256';
+}
+.li-school:before {
+  content: '\e3e6';
+}
+.li-scissors-line-dashed:before {
+  content: '\e4ed';
+}
+.li-scissors:before {
+  content: '\e151';
+}
+.li-screen-share-off:before {
+  content: '\e153';
+}
+.li-screen-share:before {
+  content: '\e152';
+}
+.li-scroll-text:before {
+  content: '\e463';
+}
+.li-scroll:before {
+  content: '\e2ec';
+}
+.li-search-check:before {
+  content: '\e4ae';
+}
+.li-search-code:before {
+  content: '\e4af';
+}
+.li-search-slash:before {
+  content: '\e4b0';
+}
+.li-search-x:before {
+  content: '\e4b1';
+}
+.li-search:before {
+  content: '\e154';
+}
+.li-section:before {
+  content: '\e5ec';
+}
+.li-send-horizontal:before {
+  content: '\e4f6';
+}
+.li-send-to-back:before {
+  content: '\e4f7';
+}
+.li-send:before {
+  content: '\e155';
+}
+.li-separator-horizontal:before {
+  content: '\e1c7';
+}
+.li-separator-vertical:before {
+  content: '\e1c8';
+}
+.li-server-cog:before {
+  content: '\e344';
+}
+.li-server-crash:before {
+  content: '\e1e8';
+}
+.li-server-off:before {
+  content: '\e1e9';
+}
+.li-server:before {
+  content: '\e156';
+}
+.li-settings-2:before {
+  content: '\e244';
+}
+.li-settings:before {
+  content: '\e157';
+}
+.li-shapes:before {
+  content: '\e4b7';
+}
+.li-share-2:before {
+  content: '\e159';
+}
+.li-share:before {
+  content: '\e158';
+}
+.li-sheet:before {
+  content: '\e15a';
+}
+.li-shell:before {
+  content: '\e4fb';
+}
+.li-shield-alert:before {
+  content: '\e1fd';
+}
+.li-shield-ban:before {
+  content: '\e15c';
+}
+.li-shield-check:before {
+  content: '\e1fe';
+}
+.li-shield-ellipsis:before {
+  content: '\e51a';
+}
+.li-shield-half:before {
+  content: '\e51b';
+}
+.li-shield-minus:before {
+  content: '\e51c';
+}
+.li-shield-off:before {
+  content: '\e15d';
+}
+.li-shield-plus:before {
+  content: '\e51d';
+}
+.li-shield-question:before {
+  content: '\e412';
+}
+.li-shield-x:before {
+  content: '\e1ff';
+}
+.li-shield:before {
+  content: '\e15b';
+}
+.li-ship-wheel:before {
+  content: '\e506';
+}
+.li-ship:before {
+  content: '\e3bd';
+}
+.li-shirt:before {
+  content: '\e1c9';
+}
+.li-shopping-bag:before {
+  content: '\e15e';
+}
+.li-shopping-basket:before {
+  content: '\e4ee';
+}
+.li-shopping-cart:before {
+  content: '\e15f';
+}
+.li-shovel:before {
+  content: '\e160';
+}
+.li-shower-head:before {
+  content: '\e37f';
+}
+.li-shrink:before {
+  content: '\e21f';
+}
+.li-shrub:before {
+  content: '\e2ed';
+}
+.li-shuffle:before {
+  content: '\e161';
+}
+.li-sigma:before {
+  content: '\e200';
+}
+.li-signal-high:before {
+  content: '\e25f';
+}
+.li-signal-low:before {
+  content: '\e260';
+}
+.li-signal-medium:before {
+  content: '\e261';
+}
+.li-signal-zero:before {
+  content: '\e262';
+}
+.li-signal:before {
+  content: '\e25e';
+}
+.li-signature:before {
+  content: '\e5f6';
+}
+.li-signpost-big:before {
+  content: '\e545';
+}
+.li-signpost:before {
+  content: '\e544';
+}
+.li-siren:before {
+  content: '\e2ee';
+}
+.li-skip-back:before {
+  content: '\e162';
+}
+.li-skip-forward:before {
+  content: '\e163';
+}
+.li-skull:before {
+  content: '\e220';
+}
+.li-slack:before {
+  content: '\e164';
+}
+.li-slash:before {
+  content: '\e521';
+}
+.li-slice:before {
+  content: '\e2ef';
+}
+.li-sliders-horizontal:before {
+  content: '\e299';
+}
+.li-sliders-vertical:before {
+  content: '\e165';
+}
+.li-smartphone-charging:before {
+  content: '\e22d';
+}
+.li-smartphone-nfc:before {
+  content: '\e3c7';
+}
+.li-smartphone:before {
+  content: '\e166';
+}
+.li-smile-plus:before {
+  content: '\e300';
+}
+.li-smile:before {
+  content: '\e167';
+}
+.li-snail:before {
+  content: '\e4fc';
+}
+.li-snowflake:before {
+  content: '\e168';
+}
+.li-sofa:before {
+  content: '\e2c3';
+}
+.li-soup:before {
+  content: '\e3ad';
+}
+.li-space:before {
+  content: '\e3e0';
+}
+.li-spade:before {
+  content: '\e49d';
+}
+.li-sparkle:before {
+  content: '\e482';
+}
+.li-sparkles:before {
+  content: '\e416';
+}
+.li-speaker:before {
+  content: '\e169';
+}
+.li-speech:before {
+  content: '\e522';
+}
+.li-spell-check-2:before {
+  content: '\e49f';
+}
+.li-spell-check:before {
+  content: '\e49e';
+}
+.li-spline:before {
+  content: '\e38e';
+}
+.li-split:before {
+  content: '\e444';
+}
+.li-spray-can:before {
+  content: '\e499';
+}
+.li-sprout:before {
+  content: '\e1ea';
+}
+.li-square-activity:before {
+  content: '\e4b8';
+}
+.li-square-arrow-down-left:before {
+  content: '\e4b9';
+}
+.li-square-arrow-down-right:before {
+  content: '\e4ba';
+}
+.li-square-arrow-down:before {
+  content: '\e42b';
+}
+.li-square-arrow-left:before {
+  content: '\e42c';
+}
+.li-square-arrow-out-down-left:before {
+  content: '\e5a5';
+}
+.li-square-arrow-out-down-right:before {
+  content: '\e5a6';
+}
+.li-square-arrow-out-up-left:before {
+  content: '\e5a7';
+}
+.li-square-arrow-out-up-right:before {
+  content: '\e5a8';
+}
+.li-square-arrow-right:before {
+  content: '\e42d';
+}
+.li-square-arrow-up-left:before {
+  content: '\e4bb';
+}
+.li-square-arrow-up-right:before {
+  content: '\e4bc';
+}
+.li-square-arrow-up:before {
+  content: '\e42e';
+}
+.li-square-asterisk:before {
+  content: '\e16b';
+}
+.li-square-bottom-dashed-scissors:before {
+  content: '\e4ef';
+}
+.li-square-chart-gantt:before {
+  content: '\e16c';
+}
+.li-square-check-big:before {
+  content: '\e16d';
+}
+.li-square-check:before {
+  content: '\e55d';
+}
+.li-square-chevron-down:before {
+  content: '\e3d2';
+}
+.li-square-chevron-left:before {
+  content: '\e3d3';
+}
+.li-square-chevron-right:before {
+  content: '\e3d4';
+}
+.li-square-chevron-up:before {
+  content: '\e3d5';
+}
+.li-square-code:before {
+  content: '\e16e';
+}
+.li-square-dashed-bottom-code:before {
+  content: '\e4c5';
+}
+.li-square-dashed-bottom:before {
+  content: '\e4c4';
+}
+.li-square-dashed-kanban:before {
+  content: '\e16f';
+}
+.li-square-dashed-mouse-pointer:before {
+  content: '\e50d';
+}
+.li-square-dashed:before {
+  content: '\e1ca';
+}
+.li-square-divide:before {
+  content: '\e170';
+}
+.li-square-dot:before {
+  content: '\e171';
+}
+.li-square-equal:before {
+  content: '\e172';
+}
+.li-square-function:before {
+  content: '\e22c';
+}
+.li-square-kanban:before {
+  content: '\e173';
+}
+.li-square-library:before {
+  content: '\e553';
+}
+.li-square-m:before {
+  content: '\e507';
+}
+.li-square-menu:before {
+  content: '\e457';
+}
+.li-square-minus:before {
+  content: '\e174';
+}
+.li-square-mouse-pointer:before {
+  content: '\e201';
+}
+.li-square-parking-off:before {
+  content: '\e3cf';
+}
+.li-square-parking:before {
+  content: '\e3ce';
+}
+.li-square-pen:before {
+  content: '\e175';
+}
+.li-square-percent:before {
+  content: '\e520';
+}
+.li-square-pi:before {
+  content: '\e48c';
+}
+.li-square-pilcrow:before {
+  content: '\e48f';
+}
+.li-square-play:before {
+  content: '\e485';
+}
+.li-square-plus:before {
+  content: '\e176';
+}
+.li-square-power:before {
+  content: '\e555';
+}
+.li-square-radical:before {
+  content: '\e5c7';
+}
+.li-square-scissors:before {
+  content: '\e4f0';
+}
+.li-square-sigma:before {
+  content: '\e48d';
+}
+.li-square-slash:before {
+  content: '\e177';
+}
+.li-square-split-horizontal:before {
+  content: '\e3b9';
+}
+.li-square-split-vertical:before {
+  content: '\e3ba';
+}
+.li-square-square:before {
+  content: '\e612';
+}
+.li-square-stack:before {
+  content: '\e4a6';
+}
+.li-square-terminal:before {
+  content: '\e209';
+}
+.li-square-user-round:before {
+  content: '\e46a';
+}
+.li-square-user:before {
+  content: '\e469';
+}
+.li-square-x:before {
+  content: '\e178';
+}
+.li-square:before {
+  content: '\e16a';
+}
+.li-squircle:before {
+  content: '\e57e';
+}
+.li-squirrel:before {
+  content: '\e4a3';
+}
+.li-stamp:before {
+  content: '\e3be';
+}
+.li-star-half:before {
+  content: '\e20a';
+}
+.li-star-off:before {
+  content: '\e2af';
+}
+.li-star:before {
+  content: '\e179';
+}
+.li-step-back:before {
+  content: '\e3ec';
+}
+.li-step-forward:before {
+  content: '\e3ed';
+}
+.li-stethoscope:before {
+  content: '\e2f0';
+}
+.li-sticker:before {
+  content: '\e301';
+}
+.li-sticky-note:before {
+  content: '\e302';
+}
+.li-store:before {
+  content: '\e3e7';
+}
+.li-stretch-horizontal:before {
+  content: '\e27b';
+}
+.li-stretch-vertical:before {
+  content: '\e27c';
+}
+.li-strikethrough:before {
+  content: '\e17a';
+}
+.li-subscript:before {
+  content: '\e25b';
+}
+.li-sun-dim:before {
+  content: '\e298';
+}
+.li-sun-medium:before {
+  content: '\e2b0';
+}
+.li-sun-moon:before {
+  content: '\e2b1';
+}
+.li-sun-snow:before {
+  content: '\e375';
+}
+.li-sun:before {
+  content: '\e17b';
+}
+.li-sunrise:before {
+  content: '\e17c';
+}
+.li-sunset:before {
+  content: '\e17d';
+}
+.li-superscript:before {
+  content: '\e25d';
+}
+.li-swatch-book:before {
+  content: '\e5a3';
+}
+.li-swiss-franc:before {
+  content: '\e17e';
+}
+.li-switch-camera:before {
+  content: '\e17f';
+}
+.li-sword:before {
+  content: '\e2b2';
+}
+.li-swords:before {
+  content: '\e2b3';
+}
+.li-syringe:before {
+  content: '\e2f1';
+}
+.li-table-2:before {
+  content: '\e2f8';
+}
+.li-table-cells-merge:before {
+  content: '\e5cb';
+}
+.li-table-cells-split:before {
+  content: '\e5cc';
+}
+.li-table-columns-split:before {
+  content: '\e5cd';
+}
+.li-table-of-contents:before {
+  content: '\e622';
+}
+.li-table-properties:before {
+  content: '\e4df';
+}
+.li-table-rows-split:before {
+  content: '\e5ce';
+}
+.li-table:before {
+  content: '\e180';
+}
+.li-tablet-smartphone:before {
+  content: '\e50e';
+}
+.li-tablet:before {
+  content: '\e181';
+}
+.li-tablets:before {
+  content: '\e3c1';
+}
+.li-tag:before {
+  content: '\e182';
+}
+.li-tags:before {
+  content: '\e35f';
+}
+.li-tally-1:before {
+  content: '\e4da';
+}
+.li-tally-2:before {
+  content: '\e4db';
+}
+.li-tally-3:before {
+  content: '\e4dc';
+}
+.li-tally-4:before {
+  content: '\e4dd';
+}
+.li-tally-5:before {
+  content: '\e4de';
+}
+.li-tangent:before {
+  content: '\e532';
+}
+.li-target:before {
+  content: '\e183';
+}
+.li-telescope:before {
+  content: '\e5c9';
+}
+.li-tent-tree:before {
+  content: '\e53f';
+}
+.li-tent:before {
+  content: '\e226';
+}
+.li-terminal:before {
+  content: '\e184';
+}
+.li-test-tube-diagonal:before {
+  content: '\e40a';
+}
+.li-test-tube:before {
+  content: '\e409';
+}
+.li-test-tubes:before {
+  content: '\e40b';
+}
+.li-text-cursor-input:before {
+  content: '\e264';
+}
+.li-text-cursor:before {
+  content: '\e263';
+}
+.li-text-quote:before {
+  content: '\e4a2';
+}
+.li-text-search:before {
+  content: '\e5b1';
+}
+.li-text-select:before {
+  content: '\e3e1';
+}
+.li-text:before {
+  content: '\e3ee';
+}
+.li-theater:before {
+  content: '\e526';
+}
+.li-thermometer-snowflake:before {
+  content: '\e186';
+}
+.li-thermometer-sun:before {
+  content: '\e187';
+}
+.li-thermometer:before {
+  content: '\e185';
+}
+.li-thumbs-down:before {
+  content: '\e188';
+}
+.li-thumbs-up:before {
+  content: '\e189';
+}
+.li-ticket-check:before {
+  content: '\e5b2';
+}
+.li-ticket-minus:before {
+  content: '\e5b3';
+}
+.li-ticket-percent:before {
+  content: '\e5b4';
+}
+.li-ticket-plus:before {
+  content: '\e5b5';
+}
+.li-ticket-slash:before {
+  content: '\e5b6';
+}
+.li-ticket-x:before {
+  content: '\e5b7';
+}
+.li-ticket:before {
+  content: '\e20e';
+}
+.li-tickets-plane:before {
+  content: '\e627';
+}
+.li-tickets:before {
+  content: '\e626';
+}
+.li-timer-off:before {
+  content: '\e248';
+}
+.li-timer-reset:before {
+  content: '\e235';
+}
+.li-timer:before {
+  content: '\e1df';
+}
+.li-toggle-left:before {
+  content: '\e18a';
+}
+.li-toggle-right:before {
+  content: '\e18b';
+}
+.li-toilet:before {
+  content: '\e639';
+}
+.li-tornado:before {
+  content: '\e217';
+}
+.li-torus:before {
+  content: '\e533';
+}
+.li-touchpad-off:before {
+  content: '\e44e';
+}
+.li-touchpad:before {
+  content: '\e44d';
+}
+.li-tower-control:before {
+  content: '\e3bf';
+}
+.li-toy-brick:before {
+  content: '\e34a';
+}
+.li-tractor:before {
+  content: '\e508';
+}
+.li-traffic-cone:before {
+  content: '\e509';
+}
+.li-train-front-tunnel:before {
+  content: '\e50b';
+}
+.li-train-front:before {
+  content: '\e50a';
+}
+.li-train-track:before {
+  content: '\e50c';
+}
+.li-tram-front:before {
+  content: '\e2a8';
+}
+.li-trash-2:before {
+  content: '\e18d';
+}
+.li-trash:before {
+  content: '\e18c';
+}
+.li-tree-deciduous:before {
+  content: '\e2f2';
+}
+.li-tree-palm:before {
+  content: '\e280';
+}
+.li-tree-pine:before {
+  content: '\e2f3';
+}
+.li-trees:before {
+  content: '\e2f4';
+}
+.li-trello:before {
+  content: '\e18e';
+}
+.li-trending-down:before {
+  content: '\e18f';
+}
+.li-trending-up-down:before {
+  content: '\e629';
+}
+.li-trending-up:before {
+  content: '\e190';
+}
+.li-triangle-alert:before {
+  content: '\e192';
+}
+.li-triangle-dashed:before {
+  content: '\e641';
+}
+.li-triangle-right:before {
+  content: '\e4f1';
+}
+.li-triangle:before {
+  content: '\e191';
+}
+.li-trophy:before {
+  content: '\e376';
+}
+.li-truck:before {
+  content: '\e193';
+}
+.li-turtle:before {
+  content: '\e4fd';
+}
+.li-tv-minimal-play:before {
+  content: '\e5f0';
+}
+.li-tv-minimal:before {
+  content: '\e202';
+}
+.li-tv:before {
+  content: '\e194';
+}
+.li-twitch:before {
+  content: '\e195';
+}
+.li-twitter:before {
+  content: '\e196';
+}
+.li-type-outline:before {
+  content: '\e606';
+}
+.li-type:before {
+  content: '\e197';
+}
+.li-umbrella-off:before {
+  content: '\e547';
+}
+.li-umbrella:before {
+  content: '\e198';
+}
+.li-underline:before {
+  content: '\e199';
+}
+.li-undo-2:before {
+  content: '\e2a0';
+}
+.li-undo-dot:before {
+  content: '\e455';
+}
+.li-undo:before {
+  content: '\e19a';
+}
+.li-unfold-horizontal:before {
+  content: '\e441';
+}
+.li-unfold-vertical:before {
+  content: '\e442';
+}
+.li-ungroup:before {
+  content: '\e46b';
+}
+.li-university:before {
+  content: '\e3e8';
+}
+.li-unlink-2:before {
+  content: '\e19c';
+}
+.li-unlink:before {
+  content: '\e19b';
+}
+.li-unplug:before {
+  content: '\e461';
+}
+.li-upload:before {
+  content: '\e19d';
+}
+.li-usb:before {
+  content: '\e359';
+}
+.li-user-check:before {
+  content: '\e19f';
+}
+.li-user-cog:before {
+  content: '\e345';
+}
+.li-user-minus:before {
+  content: '\e1a0';
+}
+.li-user-pen:before {
+  content: '\e600';
+}
+.li-user-plus:before {
+  content: '\e1a1';
+}
+.li-user-round-check:before {
+  content: '\e46d';
+}
+.li-user-round-cog:before {
+  content: '\e46e';
+}
+.li-user-round-minus:before {
+  content: '\e46f';
+}
+.li-user-round-pen:before {
+  content: '\e601';
+}
+.li-user-round-plus:before {
+  content: '\e470';
+}
+.li-user-round-search:before {
+  content: '\e57c';
+}
+.li-user-round-x:before {
+  content: '\e471';
+}
+.li-user-round:before {
+  content: '\e46c';
+}
+.li-user-search:before {
+  content: '\e57d';
+}
+.li-user-x:before {
+  content: '\e1a2';
+}
+.li-user:before {
+  content: '\e19e';
+}
+.li-users-round:before {
+  content: '\e472';
+}
+.li-users:before {
+  content: '\e1a3';
+}
+.li-utensils-crossed:before {
+  content: '\e2f6';
+}
+.li-utensils:before {
+  content: '\e2f5';
+}
+.li-utility-pole:before {
+  content: '\e3c5';
+}
+.li-variable:before {
+  content: '\e477';
+}
+.li-vault:before {
+  content: '\e593';
+}
+.li-vegan:before {
+  content: '\e3a0';
+}
+.li-venetian-mask:before {
+  content: '\e2a9';
+}
+.li-vibrate-off:before {
+  content: '\e29c';
+}
+.li-vibrate:before {
+  content: '\e222';
+}
+.li-video-off:before {
+  content: '\e1a5';
+}
+.li-video:before {
+  content: '\e1a4';
+}
+.li-videotape:before {
+  content: '\e4cf';
+}
+.li-view:before {
+  content: '\e1a6';
+}
+.li-voicemail:before {
+  content: '\e1a7';
+}
+.li-volleyball:before {
+  content: '\e633';
+}
+.li-volume-1:before {
+  content: '\e1a9';
+}
+.li-volume-2:before {
+  content: '\e1aa';
+}
+.li-volume-off:before {
+  content: '\e62a';
+}
+.li-volume-x:before {
+  content: '\e1ab';
+}
+.li-volume:before {
+  content: '\e1a8';
+}
+.li-vote:before {
+  content: '\e3b0';
+}
+.li-wallet-cards:before {
+  content: '\e4d0';
+}
+.li-wallet-minimal:before {
+  content: '\e4d1';
+}
+.li-wallet:before {
+  content: '\e203';
+}
+.li-wallpaper:before {
+  content: '\e44f';
+}
+.li-wand-sparkles:before {
+  content: '\e35a';
+}
+.li-wand:before {
+  content: '\e245';
+}
+.li-warehouse:before {
+  content: '\e3e9';
+}
+.li-washing-machine:before {
+  content: '\e594';
+}
+.li-watch:before {
+  content: '\e1ac';
+}
+.li-waves-ladder:before {
+  content: '\e63f';
+}
+.li-waves:before {
+  content: '\e282';
+}
+.li-waypoints:before {
+  content: '\e546';
+}
+.li-webcam:before {
+  content: '\e204';
+}
+.li-webhook-off:before {
+  content: '\e5bb';
+}
+.li-webhook:before {
+  content: '\e377';
+}
+.li-weight:before {
+  content: '\e534';
+}
+.li-wheat-off:before {
+  content: '\e3a2';
+}
+.li-wheat:before {
+  content: '\e3a1';
+}
+.li-whole-word:before {
+  content: '\e3e2';
+}
+.li-wifi-high:before {
+  content: '\e5fb';
+}
+.li-wifi-low:before {
+  content: '\e5fc';
+}
+.li-wifi-off:before {
+  content: '\e1ae';
+}
+.li-wifi-zero:before {
+  content: '\e5fd';
+}
+.li-wifi:before {
+  content: '\e1ad';
+}
+.li-wind-arrow-down:before {
+  content: '\e635';
+}
+.li-wind:before {
+  content: '\e1af';
+}
+.li-wine-off:before {
+  content: '\e3a3';
+}
+.li-wine:before {
+  content: '\e2f7';
+}
+.li-workflow:before {
+  content: '\e429';
+}
+.li-worm:before {
+  content: '\e5de';
+}
+.li-wrap-text:before {
+  content: '\e247';
+}
+.li-wrench:before {
+  content: '\e1b0';
+}
+.li-x:before {
+  content: '\e1b1';
+}
+.li-youtube:before {
+  content: '\e1b2';
+}
+.li-zap-off:before {
+  content: '\e1b4';
+}
+.li-zap:before {
+  content: '\e1b3';
+}
+.li-zoom-in:before {
+  content: '\e1b5';
+}
+.li-zoom-out:before {
+  content: '\e1b6';
+}

--- a/src/addons/fonts/phosphor_icons.css
+++ b/src/addons/fonts/phosphor_icons.css
@@ -1,0 +1,40 @@
+/* See all icons at: https://phosphoricons.com/ */
+
+@import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/regular/style.css';
+@import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/thin/style.css';
+@import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/light/style.css';
+@import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/bold/style.css';
+@import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/fill/style.css';
+@import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/duotone/style.css';
+
+/* Phosphor Icons */
+.ph {
+  font-family: 'Phosphor-Light' !important;
+  font-weight: unset;
+
+  /* Fill Modifiers */
+  &.icon--filled {
+    font-family: 'Phosphor-Fill' !important;
+  }
+
+  /* Weight Modifiers */
+  &.icon--weight-light {
+    font-family: 'Phosphor-Thin' !important;
+  }
+
+  &.icon--weight-normal {
+    font-family: 'Phosphor-Light' !important;
+  }
+
+  &.icon--weight-semi-bold {
+    font-family: 'Phosphor' !important;
+  }
+
+  &.icon--weight-bold {
+    font-family: 'Phosphor-Bold' !important;
+  }
+}
+
+.ph-duotone {
+  font-weight: unset;
+}

--- a/src/addons/fonts/phosphor_icons.css
+++ b/src/addons/fonts/phosphor_icons.css
@@ -1,4 +1,7 @@
-/* See all icons at: https://phosphoricons.com/ */
+/*
+  See all icons at: https://phosphoricons.com/
+  Current version: 2.1.1
+*/
 
 @import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/regular/style.css';
 @import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/thin/style.css';

--- a/src/addons/fonts/phosphor_icons.css
+++ b/src/addons/fonts/phosphor_icons.css
@@ -9,7 +9,6 @@
 
 /* Phosphor Icons */
 .ph {
-  font-family: 'Phosphor-Light' !important;
   font-weight: unset;
 
   /* Fill Modifiers */
@@ -18,15 +17,15 @@
   }
 
   /* Weight Modifiers */
-  &.icon--weight-light {
+  &.icon--weight-thin {
     font-family: 'Phosphor-Thin' !important;
   }
 
-  &.icon--weight-normal {
+  &.icon--weight-light {
     font-family: 'Phosphor-Light' !important;
   }
 
-  &.icon--weight-semi-bold {
+  &.icon--weight-normal {
     font-family: 'Phosphor' !important;
   }
 

--- a/src/addons/fonts/phosphor_icons.css
+++ b/src/addons/fonts/phosphor_icons.css
@@ -10,6 +10,8 @@
 @import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/fill/style.css';
 @import 'https://unpkg.com/@phosphor-icons/web@2.1.1/src/duotone/style.css';
 
+/* Note: the important tag is how Phosphor sets up the fonts which is why we replicate them here */
+
 /* Phosphor Icons */
 .ph {
   font-weight: unset;

--- a/src/addons/fonts/tabler_icons.css
+++ b/src/addons/fonts/tabler_icons.css
@@ -1,6 +1,8 @@
-/* See all icons at: https://tabler.io/icons */
+/*
+  See all icons at: https://tabler.io/icons
+  Current version: 3.30.0
+*/
 
-/* @import 'https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css'; */
 @import 'https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.30.0/dist/tabler-icons.min.css';
 
 /* Tabler Icons */

--- a/src/addons/fonts/tabler_icons.css
+++ b/src/addons/fonts/tabler_icons.css
@@ -1,0 +1,9 @@
+/* See all icons at: https://tabler.io/icons */
+
+/* @import 'https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css'; */
+@import 'https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.30.0/dist/tabler-icons.min.css';
+
+/* Tabler Icons */
+.ti {
+  font-weight: unset;
+}

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -8,6 +8,7 @@ class IconPackType {
     const typeMapping = {
       'Material Symbols Outlined': MaterialIconPack,
       Phosphor: PhosphorIconPack,
+      Tabler: TablerIconPack,
     }
 
     return new typeMapping[packName](packName, options)
@@ -66,6 +67,18 @@ class PhosphorIconPack extends IconPackType {
       this.options.filled ? 'icon--filled' : '',
       this.options.weight === 'normal' ? '' : `icon--weight-${this.options.weight}`,
     ].concat(super.iconClasses())
+  }
+}
+
+class TablerIconPack extends IconPackType {
+  iconElement() {
+    return 'i'
+  }
+
+  iconClasses() {
+    return ['ti', this.options.filled ? `ti-${this.options.iconName}-filled` : `ti-${this.options.iconName}`].concat(
+      super.iconClasses()
+    )
   }
 }
 

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -10,6 +10,7 @@ class IconPackType {
       Phosphor: PhosphorIconPack,
       Tabler: TablerIconPack,
       Feather: FeatherIconPack,
+      Lucide: LucideIconPack,
     }
 
     return new typeMapping[packName](packName, options)
@@ -90,6 +91,16 @@ class FeatherIconPack extends IconPackType {
 
   iconClasses() {
     return ['fi', `fi-${this.options.iconName}`].concat(super.iconClasses())
+  }
+}
+
+class LucideIconPack extends IconPackType {
+  iconElement() {
+    return 'i'
+  }
+
+  iconClasses() {
+    return ['li', `li-${this.options.iconName}`].concat(super.iconClasses())
   }
 }
 

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -1,10 +1,37 @@
-export const createIcon = ({ name, filled = false, size = 'medium', weight = 'normal', emphasis = 'normal' }) => {
+const createPhosphorElement = (name, duotone) => {
+  const icon = document.createElement('i')
+  icon.className = [duotone ? 'ph-duotone' : 'ph', `ph-${name} `].filter(Boolean).join(' ')
+  return icon
+}
+
+const createMaterialElement = (name) => {
   const icon = document.createElement('span')
   icon.innerText = name
+  icon.className = 'material-symbols-outlined '
+  return icon
+}
 
-  icon.className = [
+export const createIcon = ({
+  iconPack = 'Material Symbols Outlined',
+  name,
+  filled = false,
+  size = 'medium',
+  weight = 'normal',
+  emphasis = 'normal',
+  duotone = false,
+}) => {
+  let icon
+
+  if (iconPack === 'Phosphor') {
+    icon = createPhosphorElement(name, duotone)
+  }
+
+  if (iconPack === 'Material Symbols Outlined') {
+    icon = createMaterialElement(name)
+  }
+
+  icon.className += [
     'icon',
-    'material-symbols-outlined',
     filled ? 'icon--filled' : '',
     size === 'medium' ? '' : `icon--${size}`,
     weight === 'normal' ? '' : `icon--weight-${weight}`,

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -9,6 +9,7 @@ class IconPackType {
       'Material Symbols Outlined': MaterialIconPack,
       Phosphor: PhosphorIconPack,
       Tabler: TablerIconPack,
+      Feather: FeatherIconPack,
     }
 
     return new typeMapping[packName](packName, options)
@@ -79,6 +80,16 @@ class TablerIconPack extends IconPackType {
     return ['ti', this.options.filled ? `ti-${this.options.iconName}-filled` : `ti-${this.options.iconName}`].concat(
       super.iconClasses()
     )
+  }
+}
+
+class FeatherIconPack extends IconPackType {
+  iconElement() {
+    return 'i'
+  }
+
+  iconClasses() {
+    return ['feather', `icon-${this.options.iconName}`].concat(super.iconClasses())
   }
 }
 

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -89,7 +89,7 @@ class FeatherIconPack extends IconPackType {
   }
 
   iconClasses() {
-    return ['feather', `icon-${this.options.iconName}`].concat(super.iconClasses())
+    return ['fi', `fi-${this.options.iconName}`].concat(super.iconClasses())
   }
 }
 

--- a/src/stories/Components/Icon/Icon.js
+++ b/src/stories/Components/Icon/Icon.js
@@ -1,14 +1,72 @@
-const createPhosphorElement = (name, duotone) => {
-  const icon = document.createElement('i')
-  icon.className = [duotone ? 'ph-duotone' : 'ph', `ph-${name} `].filter(Boolean).join(' ')
-  return icon
+class IconPackType {
+  constructor(packName, options = {}) {
+    this.packName = packName
+    this.options = options
+  }
+
+  static fromNameAndOptions(packName, options) {
+    const typeMapping = {
+      'Material Symbols Outlined': MaterialIconPack,
+      Phosphor: PhosphorIconPack,
+    }
+
+    return new typeMapping[packName](packName, options)
+  }
+
+  createIcon() {
+    const icon = document.createElement(this.iconElement())
+    icon.innerText = this.innerText()
+    icon.className = this.iconClasses().filter(Boolean).join(' ')
+    return icon
+  }
+
+  iconElement() {
+    // Subclasses should override this method
+    return 'div'
+  }
+
+  innerText() {
+    // Subclasses may wish to override this method
+    return ''
+  }
+
+  iconClasses() {
+    return ['icon', this.options.size === 'medium' ? '' : `icon--${this.options.size}`]
+  }
 }
 
-const createMaterialElement = (name) => {
-  const icon = document.createElement('span')
-  icon.innerText = name
-  icon.className = 'material-symbols-outlined '
-  return icon
+class MaterialIconPack extends IconPackType {
+  iconElement() {
+    return 'span'
+  }
+
+  innerText() {
+    return this.options.iconName
+  }
+
+  iconClasses() {
+    return [
+      'material-symbols-outlined',
+      this.options.filled ? 'icon--filled' : '',
+      this.options.weight === 'normal' ? '' : `icon--weight-${this.options.weight}`,
+      this.options.emphasis === 'normal' ? '' : `icon--${this.options.emphasis}-emphasis`,
+    ].concat(super.iconClasses())
+  }
+}
+
+class PhosphorIconPack extends IconPackType {
+  iconElement() {
+    return 'i'
+  }
+
+  iconClasses() {
+    return [
+      this.options.duotone ? 'ph-duotone' : 'ph',
+      `ph-${this.options.iconName}`,
+      this.options.filled ? 'icon--filled' : '',
+      this.options.weight === 'normal' ? '' : `icon--weight-${this.options.weight}`,
+    ].concat(super.iconClasses())
+  }
 }
 
 export const createIcon = ({
@@ -20,25 +78,14 @@ export const createIcon = ({
   emphasis = 'normal',
   duotone = false,
 }) => {
-  let icon
+  const iconPackType = IconPackType.fromNameAndOptions(iconPack, {
+    iconName: name,
+    filled,
+    duotone,
+    weight,
+    size,
+    emphasis,
+  })
 
-  if (iconPack === 'Phosphor') {
-    icon = createPhosphorElement(name, duotone)
-  }
-
-  if (iconPack === 'Material Symbols Outlined') {
-    icon = createMaterialElement(name)
-  }
-
-  icon.className += [
-    'icon',
-    filled ? 'icon--filled' : '',
-    size === 'medium' ? '' : `icon--${size}`,
-    weight === 'normal' ? '' : `icon--weight-${weight}`,
-    emphasis === 'normal' ? '' : `icon--${emphasis}-emphasis`,
-  ]
-    .filter(Boolean)
-    .join(' ')
-
-  return icon
+  return iconPackType.createIcon()
 }

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -52,6 +52,42 @@ Icon can be used as a standalone component, however, it does have a few dependen
 @import '@rolemodel/optics/dist/css/components/icon';
 ```
 
+## Additional Icon Usage
+
+Optics supports the use of [additional icon packages](?path=/docs/overview-addons--docs) that can be imported alongside the core icon package. However, due to the nature of these packages, not all of the same customization options may be available.
+
+### Phosphor Icons
+
+Phosphor Icons can be created with the `<i>` tag and the class of `icon ph ph-{icon-name}`.
+
+```html
+<i class="icon ph ph-smiley"></i>
+```
+
+`.icon--filled` can be added to created a filled icon.
+
+`.icon--small`, `.icon--medium`, `.icon--large`, `.icon--x-large` (with medium being the default) modify the size of any icon.
+
+`.icon--weight-thin`, `.icon--weight-light`, `.icon--weight-normal`, `.icon--weight-bold` (with normal being the default) modify the font weight of any icon.
+
+`.ph` can be replaced with `.ph-duotone` to create a duotone effect.
+
+Note: Phosphor Icons do not support the use of emphasis variations or the use of `.icon--filled` in combination with `.ph-duotone` or any weight variations.
+
+### Tabler Icons
+
+Tabler Icons can be created with the `<i>` tag and the class of `icon ti ti-{icon-name}`.
+
+```html
+<i class="icon ti ti-settings"></i>
+```
+
+`.ti-{icon-name}` can be replaced with `.ti-{icon-name}-filled` to created a filled icon.
+
+`.icon--small`, `.icon--medium`, `.icon--large`, `.icon--x-large` (with medium being the default) modify the size of any icon.
+
+Note: Tabler Icons do not support the use of weight or emphasis variations.
+
 ## Variations
 
 ### Default

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -52,41 +52,105 @@ Icon can be used as a standalone component, however, it does have a few dependen
 @import '@rolemodel/optics/dist/css/components/icon';
 ```
 
-## Additional Icon Usage
+### Additional Icon libraries
 
-Optics supports the use of [additional icon packages](?path=/docs/overview-addons--docs) that can be imported alongside the core icon package. However, due to the nature of these packages, not all of the same customization options may be available.
+Optics supports a variety of [Additional icon libraries](?path=/docs/overview-addons--docs) that can be imported. Due to the nature of these libraries, not all of the same icon class modifiers may be available.
 
 ### Phosphor Icons
 
-Phosphor Icons can be created with the `<i>` tag and the class of `icon ph ph-{icon-name}`.
+[Phosphor Icons](https://phosphoricons.com/) can be created with the `<i>` tag and uses the `.ph` prefix with `.ph-{name}` to define a specific icon.
+
+```css
+@import '@rolemodel/optics';
+@import '@rolemodel/optics/dist/css/addons/fonts/phosphor_icons';
+```
 
 ```html
 <i class="icon ph ph-smiley"></i>
 ```
 
-`.icon--filled` can be added to created a filled icon.
+The filled, size and weight modifiers can be used with Phosphor Icons.
 
-`.icon--small`, `.icon--medium`, `.icon--large`, `.icon--x-large` (with medium being the default) modify the size of any icon.
+Phosphor adds `.icon--weight-thin` but does not support `.icon--weight-semi-bold`.
+It also adds a dual tone variation by replacing `.ph` with `.ph-duotone`.
 
-`.icon--weight-thin`, `.icon--weight-light`, `.icon--weight-normal`, `.icon--weight-bold` (with normal being the default) modify the font weight of any icon.
-
-`.ph` can be replaced with `.ph-duotone` to create a duotone effect.
+```html
+<i class="icon ph-duotone ph-smiley"></i>
+```
 
 Note: Phosphor Icons do not support the use of emphasis variations or the use of `.icon--filled` in combination with `.ph-duotone` or any weight variations.
 
 ### Tabler Icons
 
-Tabler Icons can be created with the `<i>` tag and the class of `icon ti ti-{icon-name}`.
+[Tabler Icons](https://tabler.io/icons) can be created with the `<i>` tag and uses the `.ti` prefix with `.ti-{name}` to define a specific icon.
+
+```css
+@import '@rolemodel/optics';
+@import '@rolemodel/optics/dist/css/addons/fonts/tabler_icons';
+```
 
 ```html
 <i class="icon ti ti-settings"></i>
 ```
 
-`.ti-{icon-name}` can be replaced with `.ti-{icon-name}-filled` to created a filled icon.
+The size modifiers can be used with Tabler Icons.
 
-`.icon--small`, `.icon--medium`, `.icon--large`, `.icon--x-large` (with medium being the default) modify the size of any icon.
+```html
+<i class="icon ti ti-settings icon--x-large"></i>
+```
+
+It also supports a filled variant, however, rather than using the `.icon--filled` modifier, you can replace the `ti-{name}` class with `.ti-{name}-filled`.
+
+```html
+<i class="icon ti ti-settings-filled"></i>
+```
 
 Note: Tabler Icons do not support the use of weight or emphasis variations.
+
+### Feather Icons
+
+[Feather Icons](https://feathericons.com/) can be created with the `<i>` tag and uses the `.fi` prefix with `.fi-{name}` to define a specific icon.
+
+```css
+@import '@rolemodel/optics';
+@import '@rolemodel/optics/dist/css/addons/fonts/feather_icons';
+```
+
+```html
+<i class="icon fi fi-feather"></i>
+```
+
+The size modifiers can be used with Feather Icons.
+
+```html
+<i class="icon fi fi-feather icon--x-large"></i>
+```
+
+Note: Feather Icons do not support the use of filled, weight, or emphasis variations.
+
+### Lucide Icons
+
+Lucide Icons are a fork of Feather Icons with more icons. If you don't need all the icons that Lucide provides,
+you can use the Feather Icons for a smaller icon pack instead.
+
+[Lucide Icons](https://lucide.dev/icons/) can be created with the `<i>` tag and uses the `.li` prefix with `.li-{name}` to define a specific icon.
+
+```css
+@import '@rolemodel/optics';
+@import '@rolemodel/optics/dist/css/addons/fonts/lucide_icons';
+```
+
+```html
+<i class="icon li li-banana"></i>
+```
+
+The size modifiers can be used with Lucide Icons.
+
+```html
+<i class="icon li li-banana icon--x-large"></i>
+```
+
+Note: Lucide Icons do not support the use of filled, weight, or emphasis variations.
 
 ## Variations
 

--- a/src/stories/Components/Icon/Icon.stories.js
+++ b/src/stories/Components/Icon/Icon.stories.js
@@ -8,7 +8,7 @@ export default {
   argTypes: {
     iconPack: {
       control: { type: 'select' },
-      options: ['Material Symbols Outlined', 'Phosphor', 'Tabler', 'Feather'],
+      options: ['Material Symbols Outlined', 'Phosphor', 'Tabler', 'Feather', 'Lucide'],
     },
     name: { control: 'text' },
     filled: { control: 'boolean' },

--- a/src/stories/Components/Icon/Icon.stories.js
+++ b/src/stories/Components/Icon/Icon.stories.js
@@ -8,7 +8,7 @@ export default {
   argTypes: {
     iconPack: {
       control: { type: 'select' },
-      options: ['Material Symbols Outlined', 'Phosphor', 'Tabler'],
+      options: ['Material Symbols Outlined', 'Phosphor', 'Tabler', 'Feather'],
     },
     name: { control: 'text' },
     filled: { control: 'boolean' },

--- a/src/stories/Components/Icon/Icon.stories.js
+++ b/src/stories/Components/Icon/Icon.stories.js
@@ -6,6 +6,10 @@ export default {
     return createIcon({ name, ...args })
   },
   argTypes: {
+    iconPack: {
+      control: { type: 'select' },
+      options: ['Material Symbols Outlined', 'Phosphor'],
+    },
     name: { control: 'text' },
     filled: { control: 'boolean' },
     size: {
@@ -20,17 +24,23 @@ export default {
       control: { type: 'select' },
       options: ['low', 'normal', 'high'],
     },
+    duotone: {
+      control: 'boolean',
+      if: { arg: 'iconPack', eq: 'Phosphor' },
+    },
   },
 }
 
 export const Default = {
   args: {
+    iconPack: 'Material Symbols Outlined',
     name: 'settings',
   },
 }
 
 export const Filled = {
   args: {
+    iconPack: 'Material Symbols Outlined',
     name: 'settings',
     filled: true,
   },
@@ -38,6 +48,7 @@ export const Filled = {
 
 export const Large = {
   args: {
+    iconPack: 'Material Symbols Outlined',
     name: 'settings',
     size: 'large',
   },
@@ -45,6 +56,7 @@ export const Large = {
 
 export const Bold = {
   args: {
+    iconPack: 'Material Symbols Outlined',
     name: 'settings',
     weight: 'bold',
   },
@@ -52,6 +64,7 @@ export const Bold = {
 
 export const Emphasis = {
   args: {
+    iconPack: 'Material Symbols Outlined',
     name: 'settings',
     emphasis: 'high',
   },

--- a/src/stories/Components/Icon/Icon.stories.js
+++ b/src/stories/Components/Icon/Icon.stories.js
@@ -18,7 +18,7 @@ export default {
     },
     weight: {
       control: { type: 'select' },
-      options: ['light', 'normal', 'semi-bold', 'bold'],
+      options: ['thin', 'light', 'normal', 'semi-bold', 'bold'],
     },
     emphasis: {
       control: { type: 'select' },

--- a/src/stories/Components/Icon/Icon.stories.js
+++ b/src/stories/Components/Icon/Icon.stories.js
@@ -8,7 +8,7 @@ export default {
   argTypes: {
     iconPack: {
       control: { type: 'select' },
-      options: ['Material Symbols Outlined', 'Phosphor'],
+      options: ['Material Symbols Outlined', 'Phosphor', 'Tabler'],
     },
     name: { control: 'text' },
     filled: { control: 'boolean' },

--- a/src/stories/Overview/Addons.mdx
+++ b/src/stories/Overview/Addons.mdx
@@ -15,6 +15,8 @@ Optics provides a few addons for integrating Third-Party tools with your applica
 
 ## Icon Fonts
 
+### Material Symbols Outlined
+
 Optics ships with a simplified version of [Material Symbols Outlined](https://fonts.google.com/icons?icon.style=Outlined). It only includes the font weight variable aspect of the icon library which means you won't be able to utilize the fill, or emphasis properties.
 This is a trade-off for a smaller file size which reduces page load "flash-in" where icons are blank until the font has loaded.
 This flash has been mitigated some by using the `font-display: block;` property on the font face to hide the underlying text until loaded as well as a fixed size to prevent layout shift.
@@ -26,6 +28,16 @@ This will increase the page load time but will allow you to use the full capabil
 @import '@rolemodel/optics';
 
 @import '@rolemodel/optics/dist/css/addons/fonts/material_symbols_outlined_variable';
+```
+
+### Phosphor Icons
+
+{/* Something about duotone and filled exclusive */}
+
+```css
+@import '@rolemodel/optics';
+
+@import '@rolemodel/optics/dist/css/addons/fonts/phosphor_icons';
 ```
 
 ## Tom Select

--- a/src/stories/Overview/Addons.mdx
+++ b/src/stories/Overview/Addons.mdx
@@ -21,12 +21,19 @@ Optics ships with a simplified version of [Material Symbols Outlined](https://fo
 This is a trade-off for a smaller file size which reduces page load "flash-in" where icons are blank until the font has loaded.
 This flash has been mitigated some by using the `font-display: block;` property on the font face to hide the underlying text until loaded as well as a fixed size to prevent layout shift.
 
-If your app does want to use the full Material Symbols Outlined library, you can import the full library by using the following addon.
+If your app does want to use the full Material Symbols Outlined library, you can import the full library by using the addon shown below.
 This will increase the page load time but will allow you to use the full capabilities of the icon library.
 
-### Additional Icon packs
+### Additional Icon libraries
 
-Optics also allows for selective imports of additional icon packages. The currently supported packages are [Phosphor](https://phosphoricons.com/) and [Tabler](https://tabler.io/icons). These can be imported alongside the base design system to provide additional icon options.
+Optics supports alternative icon libraries. It currently supports
+
+- [Phosphor](https://phosphoricons.com/)
+- [Tabler](https://tabler.io/icons)
+- [Feather](https://feathericons.com/)
+- [Lucide](https://lucide.dev/icons/)
+
+These can be imported alongside the base design system to provide additional icon options.
 
 For more information on how to use these icons, see the [Icon Component](?path=/docs/visual-components-icon--docs).
 
@@ -41,6 +48,12 @@ For more information on how to use these icons, see the [Icon Component](?path=/
 
 /* Tabler Icons */
 @import '@rolemodel/optics/dist/css/addons/fonts/tabler';
+
+/* Feather Icons */
+@import '@rolemodel/optics/dist/css/addons/fonts/feather';
+
+/* Lucide Icons (a fork of feather with more icons) */
+@import '@rolemodel/optics/dist/css/addons/fonts/lucide';
 ```
 
 ## Tom Select

--- a/src/stories/Overview/Addons.mdx
+++ b/src/stories/Overview/Addons.mdx
@@ -24,20 +24,23 @@ This flash has been mitigated some by using the `font-display: block;` property 
 If your app does want to use the full Material Symbols Outlined library, you can import the full library by using the following addon.
 This will increase the page load time but will allow you to use the full capabilities of the icon library.
 
+### Additional Icon packs
+
+Optics also allows for selective imports of additional icon packages. The currently supported packages are [Phosphor](https://phosphoricons.com/) and [Tabler](https://tabler.io/icons). These can be imported alongside the base design system to provide additional icon options.
+
+For more information on how to use these icons, see the [Icon Component](?path=/docs/visual-components-icon--docs).
+
 ```css
 @import '@rolemodel/optics';
 
+/* Full Material Symbols Outlined Package */
 @import '@rolemodel/optics/dist/css/addons/fonts/material_symbols_outlined_variable';
-```
 
-### Phosphor Icons
-
-{/* Something about duotone and filled exclusive */}
-
-```css
-@import '@rolemodel/optics';
-
+/* Phosphor Icons */
 @import '@rolemodel/optics/dist/css/addons/fonts/phosphor_icons';
+
+/* Tabler Icons */
+@import '@rolemodel/optics/dist/css/addons/fonts/tabler';
 ```
 
 ## Tom Select


### PR DESCRIPTION
## Why?

There has been a desire to use icon libraries other than Material Symbols Outlined.

## What Changed

- [X] Add new pattern for alternative icon libraries
- [X] Add Phosphor Icons
- [X] Add Tabler Icons
- [X] Add Feather Icons
- [X] Add Lucide Icons

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- ~~[ ] Do you need to update the package version?~~

## Screenshots


<img width="1095" alt="Screenshot 2025-02-11 at 1 54 37 PM" src="https://github.com/user-attachments/assets/011ba1fa-1ace-4941-b807-7478b36c60ba" />
<img width="1081" alt="Screenshot 2025-02-11 at 2 02 49 PM" src="https://github.com/user-attachments/assets/7bc86524-967d-4baa-9b66-d0c618e1e4bc" />
<img width="847" alt="Screenshot 2025-02-11 at 2 03 15 PM" src="https://github.com/user-attachments/assets/3b483211-f931-4d7f-8efd-7656c8229e94" />
<img width="1071" alt="Screenshot 2025-02-12 at 2 51 42 PM" src="https://github.com/user-attachments/assets/91790771-89ff-456f-8a85-22bcdc9284cb" />
<img width="1057" alt="Screenshot 2025-02-12 at 2 51 49 PM" src="https://github.com/user-attachments/assets/35ec0c02-81d6-4cb5-ab95-cb6400f8da25" />
<img width="1070" alt="Screenshot 2025-02-12 at 2 51 54 PM" src="https://github.com/user-attachments/assets/dbaa2cef-fc11-436a-bbfe-f130e672492e" />
<img width="1035" alt="Screenshot 2025-02-12 at 2 51 59 PM" src="https://github.com/user-attachments/assets/d540c9d5-b626-4d03-bb4c-2977cbb8bfc0" />
<img width="1103" alt="Screenshot 2025-02-12 at 2 52 09 PM" src="https://github.com/user-attachments/assets/48ff986d-2d05-472a-b604-d376963fe8b5" />
