### PR TITLE
Ensure distribution includes addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "packageManager": "yarn@4.2.2",
   "description": "Optics is a css package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/css/optics.css",
@@ -10,7 +10,7 @@
     "build:css": "postcss src/optics.css -o dist/css/optics.css",
     "build:css-min": "postcss src/optics.css -o dist/css/optics.min.css --env=minify",
     "build:tokens": "node build_token_json --source=src/core/tokens --output=dist/tokens/tokens.json",
-    "build:files": "mkdir -p dist/; cp LICENSE README.md package.json dist/",
+    "build:files": "mkdir -p dist/css/addons; cp LICENSE README.md package.json dist/; cp -r src/addons dist/css",
     "storybook": "storybook dev -p 6006 --docs",
     "build-storybook": "storybook build --docs",
     "lint": "yarn lint:js && yarn lint:css",


### PR DESCRIPTION
## Why?

After the recent release, the addons folder was not being included

## What Changed

- [X] Add back addons folder to distribution

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Have you updated the docs with any component changes?~~
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- [X] Do you need to update the package version? (Bumped to v2.1.1)

## Screenshots

<img width="482" alt="Screenshot 2025-03-11 at 9 48 13 AM" src="https://github.com/user-attachments/assets/28b56a67-aae8-46ba-a1dc-8b2fc9912ef6" />
