### PR TITLE
[OP-230] Update card to not use contain paint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "packageManager": "yarn@4.8.1",
   "description": "Optics is a css package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/css/optics.css",

--- a/src/components/card.css
+++ b/src/components/card.css
@@ -2,13 +2,13 @@
   /* Public API (customizable component options) */
   --_op-card-padding: var(--op-space-medium);
   --_op-card-box-shadow: var(--op-border-all) var(--op-color-border);
+  --_op-card-radius: var(--op-radius-medium);
 
   position: relative;
-  border-radius: var(--op-radius-medium);
+  border-radius: var(--_op-card-radius);
   background-color: var(--op-color-background);
   box-shadow: var(--_op-card-box-shadow);
   color: var(--op-color-on-background);
-  contain: paint;
   font-size: var(--op-font-medium);
   line-height: var(--op-line-height-base);
 
@@ -50,6 +50,9 @@
   }
 
   .card__header {
+    border-top-left-radius: var(--_op-card-radius);
+    border-top-right-radius: var(--_op-card-radius);
+
     h1,
     h2,
     h3,
@@ -58,5 +61,10 @@
     h6 {
       margin: 0;
     }
+  }
+
+  .card__footer {
+    border-bottom-left-radius: var(--_op-card-radius);
+    border-bottom-right-radius: var(--_op-card-radius);
   }
 }

--- a/src/stories/Components/Card/Card.mdx
+++ b/src/stories/Components/Card/Card.mdx
@@ -67,6 +67,16 @@ Card can be used as a standalone component, however, it does have a few dependen
 
 <Canvas of={CardStories.Shadow} />
 
+## Card API
+
+Padding, Box Shadow (border), and Radius styles are built on css variables scoped to the card. They can ben overridden to customize the card.
+
+```css
+--_op-card-padding
+--_op-card-box-shadow
+--_op-card-radius
+```
+
 ## Customizing Card styles
 
 <div
@@ -117,7 +127,8 @@ Your application may need a variation. To add one, just follow this template. No
 
 ```css
 .card--purple {
-  border-radius: var(--op-radius-large);
+  --_op-card-radius: var(--op-radius-large);
+
   font-size: var(--op-font-2x-large);
 
   .card__header {


### PR DESCRIPTION
## Why?

`contain: paint` was added to handle cases where setting a color on the card header or footer would clip the border radius set on the card. Using `contain: paint` Fixes this but then causes issues with other content like tooltips also getting clipped as it effectively acts like a `overflow: hidden`.

## What Changed

- [X] Remove usage of `contain: paint`
- [X] Add component scoped variable for setting border radius
- [X] Set border radius on header and footer so if a color is used, it won't clip
- [X] Bump version number in prep to release

## Sanity Check

- [X] Have you updated any usage of changed tokens?
- [X] Have you updated the docs with any component changes?
- ~~[ ] Have you updated the dependency graph with any component changes?~~
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- [X] Do you need to update the package version?

## Screenshots

### Before (if `contain: paint` wasn't being used)

<img width="157" alt="Screenshot 2025-06-25 at 11 26 31 AM" src="https://github.com/user-attachments/assets/2f4fbf0a-c569-42d0-a326-c87eff230fee" />

### After (Fixed without needing `contain: paint`)

<img width="117" alt="Screenshot 2025-06-25 at 11 26 33 AM" src="https://github.com/user-attachments/assets/e261a7d1-c6af-4cc2-942c-1da7993cd8e8" />
