### PR TITLE
[OP-233] Add Content Header Component

### DIFF
--- a/optics-design-system.code-workspace
+++ b/optics-design-system.code-workspace
@@ -12,6 +12,7 @@
       "source.fixAll.stylelint": "always",
     },
     "editor.formatOnSave": true,
+    "cSpell.words": ["esbenp", "graphviz", "subline", "tintinweb", "unifiedjs"],
   },
   "extensions": {
     "recommendations": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/optics",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "packageManager": "yarn@4.8.1",
   "description": "Optics is a css package that provides base styles and components that can be integrated and customized in a variety of projects.",
   "main": "dist/css/optics.css",

--- a/src/components/content-header.css
+++ b/src/components/content-header.css
@@ -1,0 +1,38 @@
+.content-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--op-space-medium);
+  padding-block: var(--op-space-medium);
+
+  .content-header__details {
+    display: grid;
+    gap: var(--op-space-3x-small);
+  }
+
+  .content-header__context {
+    color: var(--op-color-on-background-alt);
+    font-size: var(--op-font-small);
+  }
+
+  .content-header__title {
+    margin: 0;
+    color: var(--op-color-on-background);
+    font-size: var(--op-font-2x-large);
+    font-weight: var(--op-font-weight-medium);
+  }
+
+  .content-header__subline {
+    color: var(--op-color-on-background-alt);
+    font-size: var(--op-font-medium);
+  }
+
+  .content-header__aside {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: start;
+    justify-content: end;
+    gap: var(--op-space-2x-small);
+    margin-inline-start: auto;
+  }
+}

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -7,6 +7,7 @@
 @import 'button_group';
 @import 'card';
 @import 'confirm-dialog';
+@import 'content-header';
 @import 'divider';
 @import 'form';
 @import 'icon';

--- a/src/stories/Components/ContentHeader/ContentHeader.js
+++ b/src/stories/Components/ContentHeader/ContentHeader.js
@@ -1,0 +1,105 @@
+const createGitHubExample = () => {
+  return `
+<style>
+  .content-header.content-header--github-example {
+    .content-header__subline {
+      display: flex;
+      align-items: center;
+      gap: var(--op-space-2x-small);
+      font-size: var(--op-font-x-small);
+    }
+
+    .content-header__title-number {
+      color: var(--op-color-on-background-alt);
+    }
+  }
+</style>
+<header class="content-header content-header--github-example">
+  <div class="content-header__details">
+    <h1 class="content-header__title">
+      Add details to sidebar documentation
+      <span class="content-header__title-number">#265</span>
+    </h1>
+    <div class="content-header__subline">
+      <span class="badge badge--primary badge--pill">
+        <span class="material-symbols-outlined icon">graph_1</span>
+        Merged
+      </span>
+      <strong>Jeremy-Walton</strong>
+      <span>merged 1 commit into</span>
+      <div class="badge">main</div>
+      <span>from</span>
+      <div class="badge">responsive-snippet</div>
+      <a class="btn btn--no-border btn--icon btn--small" href="#">
+        <span class="material-symbols-outlined icon">content_copy</span>
+      </a>
+      <span>on Jan 31</span>
+    </div>
+  </div>
+  <div class="content-header__aside">
+    <a class="btn btn--small" href="#">Edit</a>
+    <a class="btn btn--small" href="#">
+      <span class="material-symbols-outlined icon">code</span>
+      Code
+      <span class="material-symbols-outlined icon">arrow_drop_down</span>
+    </a>
+  </div>
+</header>
+`
+}
+
+export const createContentHeader = ({
+  title = 'Content Header',
+  showContext = false,
+  contextLabel = 'Context Label',
+  showSubline = false,
+  sublineLabel = 'Subline Label',
+  showAside = false,
+  asideExample = 'actions',
+  githubExample = false,
+}) => {
+  if (githubExample) {
+    return createGitHubExample()
+  }
+
+  const element = document.createElement('header')
+
+  element.className = 'content-header'
+
+  let contextContent = ''
+  let sublineContent = ''
+
+  if (showContext) {
+    contextContent = `<span class='content-header__context'>${contextLabel}</span>`
+  }
+
+  if (showSubline) {
+    sublineContent += `<span class='content-header__subline'>${sublineLabel}</span>`
+  }
+
+  element.innerHTML = `
+  <div class='content-header__details'>
+    ${contextContent}
+    <h1 class='content-header__title'>${title}</h1>
+    ${sublineContent}
+  </div>
+  `
+
+  if (showAside) {
+    const asideElement = document.createElement('div')
+    asideElement.className = 'content-header__aside'
+    asideElement.innerHTML = '\n    <p>Aside text example</p>\n  '
+
+    if (asideExample === 'actions') {
+      asideElement.innerHTML = `
+    <button class="btn">Action 1</button>
+    <button class="btn">Action 2</button>
+  `
+    }
+    element.appendChild(asideElement)
+  }
+
+  element.innerHTML += '\n'
+
+  return element
+}

--- a/src/stories/Components/ContentHeader/ContentHeader.mdx
+++ b/src/stories/Components/ContentHeader/ContentHeader.mdx
@@ -1,0 +1,136 @@
+import { Meta, Story, Canvas, Controls } from '@storybook/blocks'
+import * as ContentHeaderStories from './ContentHeader.stories'
+import { createSourceCodeLink } from '../../helpers/sourceCodeLink.js'
+
+import { createAlert } from '../Alert/Alert.js'
+
+<Meta of={ContentHeaderStories} />
+
+# Content Header
+
+<div
+  dangerouslySetInnerHTML={{
+    __html: createSourceCodeLink({ link: 'components/content-header.css' }).outerHTML,
+  }}
+></div>
+
+Content Header classes can be used to denote a page or content section header of an application. They provide simple styles to provide context and actions for a page or section within your interface.
+
+## Playground
+
+<Canvas of={ContentHeaderStories.Default} />
+<Controls of={ContentHeaderStories.Default} />
+
+### Selective Imports
+
+Content Header can be used as a standalone component, however, it does have a few dependencies. To see a full dependency list, see [Dependency Graph](?path=/docs/overview-selective-imports--docs#dependencies)
+
+```css
+/* Depends on */
+@import '@rolemodel/optics/dist/css/core/fonts';
+@import '@rolemodel/optics/dist/css/core/tokens';
+@import '@rolemodel/optics/dist/css/core/base';
+
+/* Component */
+@import '@rolemodel/optics/dist/css/components/content-header';
+```
+
+## Variations
+
+### Default
+
+`.content-header` Provides basic content header styles.
+
+`.context-header__details` provides a section for the title, context, and subline.
+
+<Canvas of={ContentHeaderStories.Default} />
+
+### With Context
+
+`.context-header__context` provides a context label above the title.
+
+<Canvas of={ContentHeaderStories.WithContext} />
+
+### With Subline
+
+`.context-header__subline` provides a subline below the title.
+
+<Canvas of={ContentHeaderStories.WithSubline} />
+
+### With Aside
+
+`.context-header__aside` provides an aside section additional information or actions. It can hold anything you want, but is often used for page specific actions.
+
+<Canvas of={ContentHeaderStories.WithAside} />
+
+### Simple
+
+The title is really the only required part of a content header, though only really meaningful when used with actions, context, or subline.
+
+<Canvas of={ContentHeaderStories.Simple} />
+
+### GitHub Example
+
+This example demonstrates a content header with minimal customization achieving a similar look to what might be found on a GitHub pull request page.
+
+<Canvas of={ContentHeaderStories.GitHub} />
+
+## Customizing Content Header styles
+
+<div
+  dangerouslySetInnerHTML={{
+    __html: createAlert({
+      title: 'Important!',
+      description: 'These patterns represent how to customize the style of the content header for your project.',
+    }).outerHTML,
+  }}
+></div>
+
+The content header classes are structured using the [BEM methodology](https://getbem.com/naming).
+
+This allows us to define core styles on a main [block](https://getbem.com/naming/#block) class, and use [modifiers](https://getbem.com/naming/#modifier) to encapsulate variant styles. You can modify all content header behavior by overriding the `.content-header` placeholder selector and setting any properties:
+
+```css
+.content-header {
+  padding-block: var(--op-space-3x-large);
+}
+```
+
+If you need to override the behavior of the header, you can open the class and set or change properties
+
+```css
+.content-header--modifier {
+  padding-block: var(--op-space-2x-large);
+}
+```
+
+## New Content Header Variations
+
+<div
+  dangerouslySetInnerHTML={{
+    __html: createAlert({
+      title: 'Important!',
+      description: 'These patterns represent how to create new variations of the content header for your project.',
+    }).outerHTML,
+  }}
+></div>
+
+Your application may need a variation. To add one, just follow this template. Note the double hyphen, indicating that this is a [modifier](https://getbem.com/naming/#modifier):
+
+```css
+.content-header--{name} {
+  background-color: var(--op-color-primary-on-plus-four);
+
+  .content-header__context {
+    color: var(--op-color-primary-on-plus-four-alt);
+  }
+
+  .content-header__title {
+    color: var(--op-color-primary-on-plus-four);
+  }
+
+  .content-header__subline {
+    color: var(--op-color-primary-on-plus-four-alt);
+  }
+}
+```

--- a/src/stories/Components/ContentHeader/ContentHeader.stories.js
+++ b/src/stories/Components/ContentHeader/ContentHeader.stories.js
@@ -1,0 +1,74 @@
+import { createContentHeader } from './ContentHeader.js'
+
+export default {
+  title: 'Content Components/Content Header',
+  render: ({ title, ...args }) => {
+    return createContentHeader({ title, ...args })
+  },
+  argTypes: {
+    title: { control: 'text' },
+    showContext: { control: 'boolean' },
+    contextLabel: { if: { arg: 'showContext' }, control: 'text' },
+    showSubline: { control: 'boolean' },
+    sublineLabel: { if: { arg: 'showSubline' }, control: 'text' },
+    showAside: { control: 'boolean' },
+    asideExample: {
+      if: { arg: 'showAside' },
+      control: { type: 'select' },
+      options: ['actions', 'text'],
+    },
+  },
+  parameters: {
+    layout: 'padded',
+  },
+}
+
+export const Default = {
+  args: {
+    title: 'Content Header',
+    showContext: true,
+    contextLabel: 'Context Label',
+    showSubline: true,
+    sublineLabel: 'Subline Label',
+    showAside: true,
+    asideExample: 'actions',
+  },
+}
+
+export const WithContext = {
+  args: {
+    title: 'Content Header',
+    showContext: true,
+    contextLabel: 'Context Label',
+  },
+}
+
+export const WithSubline = {
+  args: {
+    title: 'Content Header',
+    showSubline: true,
+    sublineLabel: 'Subline Label',
+  },
+}
+
+export const WithAside = {
+  args: {
+    title: 'Content Header',
+    showAside: true,
+    asideExample: 'actions',
+  },
+}
+
+export const Simple = {
+  args: {
+    title: 'Only a Title',
+    showAside: true,
+    asideExample: 'actions',
+  },
+}
+
+export const GitHub = {
+  args: {
+    githubExample: true,
+  },
+}

--- a/src/stories/assets/dependency-graph.svg
+++ b/src/stories/assets/dependency-graph.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1634pt" height="260pt" viewBox="0.00 0.00 1634.16 260.00">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1757pt" height="260pt" viewBox="0.00 0.00 1757.16 260.00">
 <g id="graph0" class="graph" transform="translate(4,256) scale(1)" data-name="dependencies">
 
-<polygon fill="white" stroke="none" points="-4,4 -4,-256 1630.16,-256 1630.16,4 -4,4"/>
-<!-- Tokens &amp; Base -->
-<g id="node1" class="node" pointer-events="visible" data-name="Fonts, Tokens, Base" data-comment="Tokens &amp; Base">
+<polygon fill="white" stroke="none" points="-4,4 -4,-256 1753.16,-256 1753.16,4 -4,4"/>
+<!-- Fonts, Tokens, Base -->
+<g id="node1" class="node" pointer-events="visible" data-name="Fonts, Tokens, Base">
 
-<polygon fill="none" stroke="black" points="708.1,-36 578.99,-36 578.99,0 708.1,0 708.1,-36"/>
-<text text-anchor="middle" x="643.54" y="-13.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Fonts, Tokens, Base</text>
+<polygon fill="none" stroke="black" points="753.1,-36 623.99,-36 623.99,0 753.1,0 753.1,-36"/>
+<text text-anchor="middle" x="688.54" y="-13.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Fonts, Tokens, Base</text>
 </g>
 <!-- Accordion -->
 <g id="node2" class="node" pointer-events="visible" data-name="Accordion">
@@ -15,11 +15,11 @@
 <polygon fill="none" stroke="black" points="75.13,-180 -0.04,-180 -0.04,-144 75.13,-144 75.13,-180"/>
 <text text-anchor="middle" x="37.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Accordion</text>
 </g>
-<!-- Accordion&#45;&gt;Tokens &amp; Base -->
-<g id="edge1" class="edge" data-name="Accordion-&gt;Fonts, Tokens, Base" data-comment="Accordion-&gt;Tokens &amp; Base">
+<!-- Accordion&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge1" class="edge" data-name="Accordion-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M51.32,-143.76C69.18,-122.78 102.49,-88.15 139.54,-72 214.45,-39.34 446.02,-26.17 567.45,-21.41"/>
-<polygon fill="black" stroke="black" points="567.48,-24.91 577.34,-21.03 567.21,-17.91 567.48,-24.91"/>
+<path fill="none" stroke="black" d="M51.29,-143.71C69.14,-122.67 102.42,-88 139.54,-72 222.56,-36.23 481.74,-24.39 612.08,-20.64"/>
+<polygon fill="black" stroke="black" points="612.11,-24.15 622.01,-20.37 611.92,-17.15 612.11,-24.15"/>
 </g>
 <!-- Icon -->
 <g id="node3" class="node" pointer-events="visible" data-name="Icon">
@@ -33,11 +33,11 @@
 <path fill="none" stroke="black" d="M75.34,-147C108.24,-134.82 155.71,-117.24 188.65,-105.04"/>
 <polygon fill="black" stroke="black" points="189.64,-108.4 197.8,-101.65 187.2,-101.84 189.64,-108.4"/>
 </g>
-<!-- Icon&#45;&gt;Tokens &amp; Base -->
-<g id="edge26" class="edge" data-name="Icon-&gt;Fonts, Tokens, Base" data-comment="Icon-&gt;Tokens &amp; Base">
+<!-- Icon&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge27" class="edge" data-name="Icon-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M254,-76.51C258.46,-74.8 263.08,-73.22 267.54,-72 369.17,-44.25 490.43,-30.49 567.21,-24.07"/>
-<polygon fill="black" stroke="black" points="567.48,-27.56 577.17,-23.26 566.92,-20.59 567.48,-27.56"/>
+<path fill="none" stroke="black" d="M253.99,-76.45C258.45,-74.75 263.08,-73.18 267.54,-72 385.49,-40.73 527.05,-27.74 612.3,-22.46"/>
+<polygon fill="black" stroke="black" points="612.4,-25.96 622.18,-21.87 611.99,-18.97 612.4,-25.96"/>
 </g>
 <!-- Alert -->
 <g id="node4" class="node" pointer-events="visible" data-name="Alert">
@@ -45,11 +45,11 @@
 <polygon fill="none" stroke="black" points="147.54,-180 93.54,-180 93.54,-144 147.54,-144 147.54,-180"/>
 <text text-anchor="middle" x="120.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Alert</text>
 </g>
-<!-- Alert&#45;&gt;Tokens &amp; Base -->
-<g id="edge3" class="edge" data-name="Alert-&gt;Fonts, Tokens, Base" data-comment="Alert-&gt;Tokens &amp; Base">
+<!-- Alert&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge3" class="edge" data-name="Alert-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M126.03,-143.58C133.58,-122.75 149.31,-88.63 175.54,-72 238.95,-31.8 452.21,-22 567.7,-19.67"/>
-<polygon fill="black" stroke="black" points="567.46,-23.18 577.39,-19.49 567.33,-16.18 567.46,-23.18"/>
+<path fill="none" stroke="black" d="M126.01,-143.54C133.53,-122.67 149.23,-88.5 175.54,-72 246.53,-27.49 487.91,-19.73 612.6,-18.78"/>
+<polygon fill="black" stroke="black" points="612.44,-22.28 622.42,-18.72 612.4,-15.28 612.44,-22.28"/>
 </g>
 <!-- Alert&#45;&gt;Icon -->
 <g id="edge4" class="edge" data-name="Alert-&gt;Icon">
@@ -63,11 +63,11 @@
 <polygon fill="none" stroke="black" points="219.54,-180 165.54,-180 165.54,-144 219.54,-144 219.54,-180"/>
 <text text-anchor="middle" x="192.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Badge</text>
 </g>
-<!-- Badge&#45;&gt;Tokens &amp; Base -->
-<g id="edge5" class="edge" data-name="Badge-&gt;Fonts, Tokens, Base" data-comment="Badge-&gt;Tokens &amp; Base">
+<!-- Badge&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge5" class="edge" data-name="Badge-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M185.88,-143.56C179.54,-123.66 173.28,-91.4 190.54,-72 215.14,-44.36 445.31,-28.83 567.75,-22.46"/>
-<polygon fill="black" stroke="black" points="567.58,-25.97 577.38,-21.96 567.22,-18.98 567.58,-25.97"/>
+<path fill="none" stroke="black" d="M185.84,-143.52C179.47,-123.6 173.18,-91.31 190.54,-72 218.19,-41.26 479.67,-26.94 612.25,-21.61"/>
+<polygon fill="black" stroke="black" points="612.14,-25.12 621.99,-21.23 611.86,-18.12 612.14,-25.12"/>
 </g>
 <!-- Badge&#45;&gt;Icon -->
 <g id="edge6" class="edge" data-name="Badge-&gt;Icon">
@@ -81,11 +81,11 @@
 <polygon fill="none" stroke="black" points="439.66,-180 385.43,-180 385.43,-144 439.66,-144 439.66,-180"/>
 <text text-anchor="middle" x="412.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Button</text>
 </g>
-<!-- Button&#45;&gt;Tokens &amp; Base -->
-<g id="edge7" class="edge" data-name="Button-&gt;Fonts, Tokens, Base" data-comment="Button-&gt;Tokens &amp; Base">
+<!-- Button&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge7" class="edge" data-name="Button-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M415.95,-143.61C420.8,-123.46 431.66,-90.64 453.54,-72 485.22,-45.02 529.63,-31.71 567.55,-25.17"/>
-<polygon fill="black" stroke="black" points="567.75,-28.68 577.08,-23.66 566.65,-21.77 567.75,-28.68"/>
+<path fill="none" stroke="black" d="M415.71,-143.78C420.36,-123.47 431.07,-90.2 453.54,-72 477.79,-52.38 553.54,-37.63 612.56,-28.74"/>
+<polygon fill="black" stroke="black" points="612.86,-32.23 622.25,-27.31 611.84,-25.31 612.86,-32.23"/>
 </g>
 <!-- Button&#45;&gt;Icon -->
 <g id="edge8" class="edge" data-name="Button-&gt;Icon">
@@ -99,11 +99,11 @@
 <polygon fill="none" stroke="black" points="291.54,-180 237.54,-180 237.54,-144 291.54,-144 291.54,-180"/>
 <text text-anchor="middle" x="264.54" y="-157.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tag</text>
 </g>
-<!-- Tag&#45;&gt;Tokens &amp; Base -->
-<g id="edge9" class="edge" data-name="Tag-&gt;Fonts, Tokens, Base" data-comment="Tag-&gt;Tokens &amp; Base">
+<!-- Tag&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge9" class="edge" data-name="Tag-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M267.51,-143.52C271.96,-122.97 282.47,-89.44 305.54,-72 345.68,-41.66 480.69,-28.27 567.45,-22.68"/>
-<polygon fill="black" stroke="black" points="567.55,-26.18 577.32,-22.06 567.12,-19.19 567.55,-26.18"/>
+<path fill="none" stroke="black" d="M267.38,-143.81C271.74,-123.22 282.18,-89.33 305.54,-72 352.8,-36.94 514.94,-25.04 612.46,-21.03"/>
+<polygon fill="black" stroke="black" points="612.36,-24.53 622.22,-20.65 612.09,-17.54 612.36,-24.53"/>
 </g>
 <!-- Tag&#45;&gt;Icon -->
 <g id="edge10" class="edge" data-name="Tag-&gt;Icon">
@@ -117,11 +117,11 @@
 <polygon fill="none" stroke="black" points="344.44,-252 250.65,-252 250.65,-216 344.44,-216 344.44,-252"/>
 <text text-anchor="middle" x="297.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Button Group</text>
 </g>
-<!-- Button Group&#45;&gt;Tokens &amp; Base -->
-<g id="edge11" class="edge" data-name="Button Group-&gt;Fonts, Tokens, Base" data-comment="Button Group-&gt;Tokens &amp; Base">
+<!-- Button Group&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge11" class="edge" data-name="Button Group-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M302.01,-215.71C311.59,-182.25 337.44,-108.73 387.54,-72 415.69,-51.37 502.38,-36.4 567.14,-27.74"/>
-<polygon fill="black" stroke="black" points="567.59,-31.21 577.05,-26.44 566.68,-24.27 567.59,-31.21"/>
+<path fill="none" stroke="black" d="M301.8,-215.58C311,-181.89 336.11,-107.99 386.54,-72 421.96,-46.73 535.28,-32.12 612.57,-24.86"/>
+<polygon fill="black" stroke="black" points="612.55,-28.38 622.19,-23.98 611.92,-21.41 612.55,-28.38"/>
 </g>
 <!-- Button Group&#45;&gt;Button -->
 <g id="edge12" class="edge" data-name="Button Group-&gt;Button">
@@ -135,11 +135,11 @@
 <polygon fill="none" stroke="black" points="420.81,-252 362.28,-252 362.28,-216 420.81,-216 420.81,-252"/>
 <text text-anchor="middle" x="391.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Sidebar</text>
 </g>
-<!-- Sidebar&#45;&gt;Tokens &amp; Base -->
-<g id="edge13" class="edge" data-name="Sidebar-&gt;Fonts, Tokens, Base" data-comment="Sidebar-&gt;Tokens &amp; Base">
+<!-- Sidebar&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge13" class="edge" data-name="Sidebar-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M383.94,-215.63C377.06,-197.46 369.07,-168.26 376.54,-144 387.94,-107.01 393.73,-94.04 425.54,-72 467.22,-43.13 522.88,-29.91 567.52,-23.9"/>
-<polygon fill="black" stroke="black" points="567.92,-27.38 577.41,-22.67 567.06,-20.43 567.92,-27.38"/>
+<path fill="none" stroke="black" d="M383.94,-215.63C377.06,-197.46 369.07,-168.26 376.54,-144 387.94,-107.01 393.3,-93.41 425.54,-72 455.67,-52 546,-36.76 612.42,-27.87"/>
+<polygon fill="black" stroke="black" points="612.73,-31.36 622.19,-26.59 611.82,-24.42 612.73,-31.36"/>
 </g>
 <!-- Sidebar&#45;&gt;Button -->
 <g id="edge14" class="edge" data-name="Sidebar-&gt;Button">
@@ -153,11 +153,11 @@
 <polygon fill="none" stroke="black" points="496.25,-252 438.84,-252 438.84,-216 496.25,-216 496.25,-252"/>
 <text text-anchor="middle" x="467.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Navbar</text>
 </g>
-<!-- Navbar&#45;&gt;Tokens &amp; Base -->
-<g id="edge15" class="edge" data-name="Navbar-&gt;Fonts, Tokens, Base" data-comment="Navbar-&gt;Tokens &amp; Base">
+<!-- Navbar&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge15" class="edge" data-name="Navbar-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M469.07,-215.68C472.79,-183.45 485.03,-113.78 523.54,-72 535.82,-58.69 552.04,-48.53 568.58,-40.86"/>
-<polygon fill="black" stroke="black" points="569.71,-44.18 577.49,-36.99 566.92,-37.76 569.71,-44.18"/>
+<path fill="none" stroke="black" d="M468.27,-215.54C470.58,-182.78 480.24,-111.81 520.54,-72 545.07,-47.78 580.57,-34.61 612.62,-27.46"/>
+<polygon fill="black" stroke="black" points="613.21,-30.91 622.3,-25.48 611.81,-24.05 613.21,-30.91"/>
 </g>
 <!-- Navbar&#45;&gt;Button -->
 <g id="edge16" class="edge" data-name="Navbar-&gt;Button">
@@ -171,11 +171,11 @@
 <polygon fill="none" stroke="black" points="590.43,-252 514.66,-252 514.66,-216 590.43,-216 590.43,-252"/>
 <text text-anchor="middle" x="552.54" y="-229.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Pagination</text>
 </g>
-<!-- Pagination&#45;&gt;Tokens &amp; Base -->
-<g id="edge19" class="edge" data-name="Pagination-&gt;Fonts, Tokens, Base" data-comment="Pagination-&gt;Tokens &amp; Base">
+<!-- Pagination&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge19" class="edge" data-name="Pagination-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M540.66,-215.72C534.53,-205.76 527.7,-192.73 524.54,-180 512.66,-132.08 518.75,-109.77 550.54,-72 560.95,-59.64 575,-49.57 589.03,-41.65"/>
-<polygon fill="black" stroke="black" points="590.66,-44.75 597.86,-36.97 587.38,-38.56 590.66,-44.75"/>
+<path fill="none" stroke="black" d="M540.66,-215.72C534.53,-205.76 527.7,-192.73 524.54,-180 512.71,-132.27 514.48,-107.46 548.54,-72 565.72,-54.12 589.53,-42.21 612.66,-34.3"/>
+<polygon fill="black" stroke="black" points="613.65,-37.65 622.12,-31.29 611.53,-30.98 613.65,-37.65"/>
 </g>
 <!-- Pagination&#45;&gt;Button -->
 <g id="edge17" class="edge" data-name="Pagination-&gt;Button">
@@ -195,11 +195,11 @@
 <path fill="none" stroke="black" d="M554.52,-215.7C555.36,-208.41 556.35,-199.73 557.28,-191.54"/>
 <polygon fill="black" stroke="black" points="560.76,-191.94 558.42,-181.61 553.81,-191.15 560.76,-191.94"/>
 </g>
-<!-- Form&#45;&gt;Tokens &amp; Base -->
-<g id="edge25" class="edge" data-name="Form-&gt;Fonts, Tokens, Base" data-comment="Form-&gt;Tokens &amp; Base">
+<!-- Form&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge26" class="edge" data-name="Form-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M556.43,-143.71C552.91,-124.82 550.16,-94.29 562.54,-72 569.24,-59.95 579.96,-50.18 591.44,-42.46"/>
-<polygon fill="black" stroke="black" points="593.22,-45.48 599.9,-37.26 589.55,-39.52 593.22,-45.48"/>
+<path fill="none" stroke="black" d="M555.76,-143.6C551.55,-124.34 548.11,-93.21 562.54,-72 574.49,-54.46 593.46,-42.7 613.1,-34.83"/>
+<polygon fill="black" stroke="black" points="614.1,-38.19 622.29,-31.47 611.69,-31.62 614.1,-38.19"/>
 </g>
 <!-- Avatar -->
 <g id="node13" class="node" pointer-events="visible" data-name="Avatar">
@@ -207,11 +207,11 @@
 <polygon fill="none" stroke="black" points="625.63,-108 571.46,-108 571.46,-72 625.63,-72 625.63,-108"/>
 <text text-anchor="middle" x="598.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Avatar</text>
 </g>
-<!-- Avatar&#45;&gt;Tokens &amp; Base -->
-<g id="edge20" class="edge" data-name="Avatar-&gt;Fonts, Tokens, Base" data-comment="Avatar-&gt;Tokens &amp; Base">
+<!-- Avatar&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge20" class="edge" data-name="Avatar-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M609.67,-71.7C614.74,-63.81 620.85,-54.3 626.48,-45.55"/>
-<polygon fill="black" stroke="black" points="629.27,-47.68 631.73,-37.38 623.38,-43.9 629.27,-47.68"/>
+<path fill="none" stroke="black" d="M620.79,-71.7C631.83,-63.11 645.34,-52.61 657.38,-43.24"/>
+<polygon fill="black" stroke="black" points="659.3,-46.18 665.05,-37.28 655,-40.65 659.3,-46.18"/>
 </g>
 <!-- Breadcrumbs -->
 <g id="node14" class="node" pointer-events="visible" data-name="Breadcrumbs">
@@ -219,11 +219,11 @@
 <polygon fill="none" stroke="black" points="733.69,-108 643.4,-108 643.4,-72 733.69,-72 733.69,-108"/>
 <text text-anchor="middle" x="688.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Breadcrumbs</text>
 </g>
-<!-- Breadcrumbs&#45;&gt;Tokens &amp; Base -->
-<g id="edge21" class="edge" data-name="Breadcrumbs-&gt;Fonts, Tokens, Base" data-comment="Breadcrumbs-&gt;Tokens &amp; Base">
+<!-- Breadcrumbs&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge21" class="edge" data-name="Breadcrumbs-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M677.42,-71.7C672.35,-63.81 666.24,-54.3 660.61,-45.55"/>
-<polygon fill="black" stroke="black" points="663.71,-43.9 655.36,-37.38 657.82,-47.68 663.71,-43.9"/>
+<path fill="none" stroke="black" d="M688.54,-71.7C688.54,-64.41 688.54,-55.73 688.54,-47.54"/>
+<polygon fill="black" stroke="black" points="692.05,-47.62 688.54,-37.62 685.05,-47.62 692.05,-47.62"/>
 </g>
 <!-- Card -->
 <g id="node15" class="node" pointer-events="visible" data-name="Card">
@@ -231,131 +231,143 @@
 <polygon fill="none" stroke="black" points="805.54,-108 751.54,-108 751.54,-72 805.54,-72 805.54,-108"/>
 <text text-anchor="middle" x="778.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Card</text>
 </g>
-<!-- Card&#45;&gt;Tokens &amp; Base -->
-<g id="edge22" class="edge" data-name="Card-&gt;Fonts, Tokens, Base" data-comment="Card-&gt;Tokens &amp; Base">
+<!-- Card&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge22" class="edge" data-name="Card-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M751.23,-74.83C732.82,-65.29 708.14,-52.5 687.06,-41.56"/>
-<polygon fill="black" stroke="black" points="688.87,-38.56 678.38,-37.06 685.65,-44.78 688.87,-38.56"/>
+<path fill="none" stroke="black" d="M756.3,-71.7C745.26,-63.11 731.75,-52.61 719.71,-43.24"/>
+<polygon fill="black" stroke="black" points="722.09,-40.65 712.04,-37.28 717.79,-46.18 722.09,-40.65"/>
 </g>
 <!-- Confirm Dialog -->
-<g id="node16" class="node" pointer-events="visible" data-name="Confirm Dialog">
+<g id="node17" class="node" pointer-events="visible" data-name="Confirm Dialog">
 
-<polygon fill="none" stroke="black" points="929.09,-108 824,-108 824,-72 929.09,-72 929.09,-108"/>
-<text text-anchor="middle" x="876.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Confirm Dialog</text>
+<polygon fill="none" stroke="black" points="1052.09,-108 947,-108 947,-72 1052.09,-72 1052.09,-108"/>
+<text text-anchor="middle" x="999.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Confirm Dialog</text>
+</g><g id="node16" class="node" pointer-events="visible" data-name="Content-Header" data-comment="Confirm Dialog">
+
+<polygon fill="none" stroke="black" points="929.45,-108 823.64,-108 823.64,-72 929.45,-72 929.45,-108"/>
+<text text-anchor="middle" x="876.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Content-Header</text>
 </g>
-<!-- Confirm Dialog&#45;&gt;Tokens &amp; Base -->
-<g id="edge23" class="edge" data-name="Confirm Dialog-&gt;Fonts, Tokens, Base" data-comment="Confirm Dialog-&gt;Tokens &amp; Base">
+<!-- Confirm Dialog&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge24" class="edge" data-name="Confirm Dialog-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M823.67,-73.12C790.7,-63.21 747.91,-50.36 712.31,-39.66"/>
-<polygon fill="black" stroke="black" points="713.55,-36.38 702.97,-36.85 711.54,-43.08 713.55,-36.38"/>
+<path fill="none" stroke="black" d="M946.7,-74.05C943.94,-73.34 941.21,-72.65 938.54,-72 880.45,-57.76 814.22,-43.82 764.53,-33.82"/>
+<polygon fill="black" stroke="black" points="765.52,-30.45 755.03,-31.91 764.15,-37.31 765.52,-30.45"/>
+</g><g id="edge23" class="edge" data-name="Content-Header-&gt;Fonts, Tokens, Base" data-comment="Confirm Dialog-&gt;Fonts, Tokens, Base">
+
+<path fill="none" stroke="black" d="M829.59,-71.52C804.26,-62.08 772.79,-50.37 746,-40.39"/>
+<polygon fill="black" stroke="black" points="747.24,-37.12 736.65,-36.91 744.8,-43.68 747.24,-37.12"/>
 </g>
 <!-- Divider -->
-<g id="node17" class="node" pointer-events="visible" data-name="Divider">
+<g id="node18" class="node" pointer-events="visible" data-name="Divider">
 
-<polygon fill="none" stroke="black" points="1005.81,-108 947.28,-108 947.28,-72 1005.81,-72 1005.81,-108"/>
-<text text-anchor="middle" x="976.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Divider</text>
+<polygon fill="none" stroke="black" points="1128.81,-108 1070.28,-108 1070.28,-72 1128.81,-72 1128.81,-108"/>
+<text text-anchor="middle" x="1099.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Divider</text>
 </g>
-<!-- Divider&#45;&gt;Tokens &amp; Base -->
-<g id="edge24" class="edge" data-name="Divider-&gt;Fonts, Tokens, Base" data-comment="Divider-&gt;Tokens &amp; Base">
+<!-- Divider&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge25" class="edge" data-name="Divider-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M946.94,-74.94C944.13,-73.85 941.31,-72.85 938.54,-72 865.91,-49.59 780.11,-35.5 719.82,-27.53"/>
-<polygon fill="black" stroke="black" points="720.36,-24.07 709.99,-26.26 719.46,-31.01 720.36,-24.07"/>
+<path fill="none" stroke="black" d="M1069.97,-74.83C1067.16,-73.77 1064.32,-72.8 1061.54,-72 961.27,-43.07 841.09,-29.61 764.78,-23.58"/>
+<polygon fill="black" stroke="black" points="765.13,-20.1 754.89,-22.82 764.59,-27.08 765.13,-20.1"/>
 </g>
 <!-- Modal -->
-<g id="node18" class="node" pointer-events="visible" data-name="Modal">
+<g id="node19" class="node" pointer-events="visible" data-name="Modal">
 
-<polygon fill="none" stroke="black" points="1077.54,-108 1023.54,-108 1023.54,-72 1077.54,-72 1077.54,-108"/>
-<text text-anchor="middle" x="1050.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Modal</text>
+<polygon fill="none" stroke="black" points="1200.54,-108 1146.54,-108 1146.54,-72 1200.54,-72 1200.54,-108"/>
+<text text-anchor="middle" x="1173.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Modal</text>
 </g>
-<!-- Modal&#45;&gt;Tokens &amp; Base -->
-<g id="edge27" class="edge" data-name="Modal-&gt;Fonts, Tokens, Base" data-comment="Modal-&gt;Tokens &amp; Base">
+<!-- Modal&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge28" class="edge" data-name="Modal-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1023.36,-75.13C1020.43,-73.95 1017.46,-72.87 1014.54,-72 915.26,-42.21 795.86,-28.97 719.84,-23.22"/>
-<polygon fill="black" stroke="black" points="720.22,-19.74 709.99,-22.5 719.71,-26.72 720.22,-19.74"/>
+<path fill="none" stroke="black" d="M1146.38,-75.06C1143.45,-73.89 1140.47,-72.84 1137.54,-72 1010.02,-35.42 855.16,-24.04 764.65,-20.53"/>
+<polygon fill="black" stroke="black" points="765.04,-17.04 754.91,-20.18 764.78,-24.04 765.04,-17.04"/>
 </g>
 <!-- Side Panel -->
-<g id="node19" class="node" pointer-events="visible" data-name="Side Panel">
+<g id="node20" class="node" pointer-events="visible" data-name="Side Panel">
 
-<polygon fill="none" stroke="black" points="1171.54,-108 1095.55,-108 1095.55,-72 1171.54,-72 1171.54,-108"/>
-<text text-anchor="middle" x="1133.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Side Panel</text>
+<polygon fill="none" stroke="black" points="1294.54,-108 1218.55,-108 1218.55,-72 1294.54,-72 1294.54,-108"/>
+<text text-anchor="middle" x="1256.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Side Panel</text>
 </g>
-<!-- Side Panel&#45;&gt;Tokens &amp; Base -->
-<g id="edge28" class="edge" data-name="Side Panel-&gt;Fonts, Tokens, Base" data-comment="Side Panel-&gt;Tokens &amp; Base">
+<!-- Side Panel&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge29" class="edge" data-name="Side Panel-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1095.29,-74.36C1092.35,-73.48 1089.42,-72.68 1086.54,-72 960.02,-41.96 808.91,-28.53 719.89,-22.84"/>
-<polygon fill="black" stroke="black" points="720.25,-19.36 710.06,-22.23 719.82,-26.34 720.25,-19.36"/>
+<path fill="none" stroke="black" d="M1218.3,-74.3C1215.36,-73.44 1212.42,-72.66 1209.54,-72 1054.2,-36.57 867.39,-24.81 764.99,-20.92"/>
+<polygon fill="black" stroke="black" points="765.17,-17.42 755.05,-20.56 764.92,-24.42 765.17,-17.42"/>
 </g>
 <!-- Spinner -->
-<g id="node20" class="node" pointer-events="visible" data-name="Spinner">
+<g id="node21" class="node" pointer-events="visible" data-name="Spinner">
 
-<polygon fill="none" stroke="black" points="1249.1,-108 1189.99,-108 1189.99,-72 1249.1,-72 1249.1,-108"/>
-<text text-anchor="middle" x="1219.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Spinner</text>
+<polygon fill="none" stroke="black" points="1372.1,-108 1312.99,-108 1312.99,-72 1372.1,-72 1372.1,-108"/>
+<text text-anchor="middle" x="1342.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Spinner</text>
 </g>
-<!-- Spinner&#45;&gt;Tokens &amp; Base -->
-<g id="edge29" class="edge" data-name="Spinner-&gt;Fonts, Tokens, Base" data-comment="Spinner-&gt;Tokens &amp; Base">
+<!-- Spinner&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge30" class="edge" data-name="Spinner-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1189.64,-74.86C1186.61,-73.76 1183.55,-72.78 1180.54,-72 1020.2,-30.25 825.09,-20.89 719.79,-19.09"/>
-<polygon fill="black" stroke="black" points="719.9,-15.6 709.84,-18.94 719.79,-22.59 719.9,-15.6"/>
+<path fill="none" stroke="black" d="M1312.65,-74.82C1309.62,-73.73 1306.55,-72.76 1303.54,-72 1203.48,-46.61 905.72,-29.42 764.49,-22.47"/>
+<polygon fill="black" stroke="black" points="765.04,-18.99 754.88,-22 764.7,-25.98 765.04,-18.99"/>
 </g>
 <!-- Switch -->
-<g id="node21" class="node" pointer-events="visible" data-name="Switch">
+<g id="node22" class="node" pointer-events="visible" data-name="Switch">
 
-<polygon fill="none" stroke="black" points="1321.93,-108 1267.16,-108 1267.16,-72 1321.93,-72 1321.93,-108"/>
-<text text-anchor="middle" x="1294.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Switch</text>
+<polygon fill="none" stroke="black" points="1444.93,-108 1390.16,-108 1390.16,-72 1444.93,-72 1444.93,-108"/>
+<text text-anchor="middle" x="1417.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Switch</text>
 </g>
-<!-- Switch&#45;&gt;Tokens &amp; Base -->
-<g id="edge30" class="edge" data-name="Switch-&gt;Fonts, Tokens, Base" data-comment="Switch-&gt;Tokens &amp; Base">
+<!-- Switch&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge31" class="edge" data-name="Switch-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1267.01,-74.81C1264.2,-73.72 1261.35,-72.76 1258.54,-72 1158.88,-45.1 860.91,-28.67 719.56,-22.19"/>
-<polygon fill="black" stroke="black" points="720.09,-18.71 709.94,-21.75 719.77,-25.7 720.09,-18.71"/>
+<path fill="none" stroke="black" d="M1390.02,-74.78C1387.21,-73.7 1384.35,-72.74 1381.54,-72 1266.89,-41.65 919.69,-26.66 764.69,-21.34"/>
+<polygon fill="black" stroke="black" points="765.04,-17.85 754.93,-21.01 764.81,-24.84 765.04,-17.85"/>
 </g>
 <!-- Tab -->
-<g id="node22" class="node" pointer-events="visible" data-name="Tab">
+<g id="node23" class="node" pointer-events="visible" data-name="Tab">
 
-<polygon fill="none" stroke="black" points="1393.54,-108 1339.54,-108 1339.54,-72 1393.54,-72 1393.54,-108"/>
-<text text-anchor="middle" x="1366.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tab</text>
+<polygon fill="none" stroke="black" points="1516.54,-108 1462.54,-108 1462.54,-72 1516.54,-72 1516.54,-108"/>
+<text text-anchor="middle" x="1489.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tab</text>
 </g>
-<!-- Tab&#45;&gt;Tokens &amp; Base -->
-<g id="edge31" class="edge" data-name="Tab-&gt;Fonts, Tokens, Base" data-comment="Tab-&gt;Tokens &amp; Base">
+<!-- Tab&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge32" class="edge" data-name="Tab-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1339.42,-74.94C1336.48,-73.79 1333.48,-72.78 1330.54,-72 1217.03,-41.91 873.54,-26.8 719.6,-21.39"/>
-<polygon fill="black" stroke="black" points="720.03,-17.9 709.92,-21.06 719.79,-24.9 720.03,-17.9"/>
+<path fill="none" stroke="black" d="M1462.42,-74.91C1459.48,-73.77 1456.49,-72.77 1453.54,-72 1324.94,-38.45 931.6,-24.99 764.7,-20.7"/>
+<polygon fill="black" stroke="black" points="765.16,-17.21 755.07,-20.45 764.98,-24.2 765.16,-17.21"/>
 </g>
 <!-- Table -->
-<g id="node23" class="node" pointer-events="visible" data-name="Table">
+<g id="node24" class="node" pointer-events="visible" data-name="Table">
 
-<polygon fill="none" stroke="black" points="1465.54,-108 1411.54,-108 1411.54,-72 1465.54,-72 1465.54,-108"/>
-<text text-anchor="middle" x="1438.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Table</text>
+<polygon fill="none" stroke="black" points="1588.54,-108 1534.54,-108 1534.54,-72 1588.54,-72 1588.54,-108"/>
+<text text-anchor="middle" x="1561.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Table</text>
 </g>
-<!-- Table&#45;&gt;Tokens &amp; Base -->
-<g id="edge32" class="edge" data-name="Table-&gt;Fonts, Tokens, Base" data-comment="Table-&gt;Tokens &amp; Base">
+<!-- Table&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge33" class="edge" data-name="Table-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1411.42,-74.91C1408.48,-73.77 1405.49,-72.77 1402.54,-72 1275.03,-38.7 885.17,-25.11 719.41,-20.74"/>
-<polygon fill="black" stroke="black" points="719.94,-17.25 709.86,-20.49 719.76,-24.25 719.94,-17.25"/>
+<path fill="none" stroke="black" d="M1534.43,-74.9C1531.49,-73.76 1528.49,-72.76 1525.54,-72 1382.92,-35.25 942.99,-23.48 764.73,-20.17"/>
+<polygon fill="black" stroke="black" points="764.95,-16.67 754.89,-19.99 764.82,-23.67 764.95,-16.67"/>
 </g>
 <!-- Text Pair -->
-<g id="node24" class="node" pointer-events="visible" data-name="Text Pair">
+<g id="node25" class="node" pointer-events="visible" data-name="Text Pair">
 
-<polygon fill="none" stroke="black" points="1551.25,-108 1483.84,-108 1483.84,-72 1551.25,-72 1551.25,-108"/>
-<text text-anchor="middle" x="1517.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Text Pair</text>
+<polygon fill="none" stroke="black" points="1674.25,-108 1606.84,-108 1606.84,-72 1674.25,-72 1674.25,-108"/>
+<text text-anchor="middle" x="1640.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Text Pair</text>
 </g>
-<!-- Text Pair&#45;&gt;Tokens &amp; Base -->
-<g id="edge33" class="edge" data-name="Text Pair-&gt;Fonts, Tokens, Base" data-comment="Text Pair-&gt;Tokens &amp; Base">
+<!-- Text Pair&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge34" class="edge" data-name="Text Pair-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1483.58,-74.46C1480.56,-73.51 1477.52,-72.67 1474.54,-72 1332.01,-40.11 896.76,-25.54 719.68,-20.82"/>
-<polygon fill="black" stroke="black" points="720,-17.33 709.91,-20.56 719.82,-24.33 720,-17.33"/>
+<path fill="none" stroke="black" d="M1606.59,-74.44C1603.57,-73.49 1600.52,-72.66 1597.54,-72 1439.73,-37.15 954.13,-24.16 765.03,-20.34"/>
+<polygon fill="black" stroke="black" points="765.13,-16.84 755.06,-20.14 764.99,-23.84 765.13,-16.84"/>
 </g>
 <!-- Tooltip -->
-<g id="node25" class="node" pointer-events="visible" data-name="Tooltip">
+<g id="node26" class="node" pointer-events="visible" data-name="Tooltip">
 
-<polygon fill="none" stroke="black" points="1626.27,-108 1568.82,-108 1568.82,-72 1626.27,-72 1626.27,-108"/>
-<text text-anchor="middle" x="1597.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tooltip</text>
+<polygon fill="none" stroke="black" points="1749.27,-108 1691.82,-108 1691.82,-72 1749.27,-72 1749.27,-108"/>
+<text text-anchor="middle" x="1720.54" y="-85.8" font-family="Helvetica,Arial,sans-serif" font-size="14.00">Tooltip</text>
 </g>
-<!-- Tooltip&#45;&gt;Tokens &amp; Base -->
-<g id="edge34" class="edge" data-name="Tooltip-&gt;Fonts, Tokens, Base" data-comment="Tooltip-&gt;Tokens &amp; Base">
+<!-- Tooltip&#45;&gt;Fonts, Tokens, Base -->
+<!-- Tooltip&#45;&gt;Fonts, Tokens, Base -->
+<!-- Tooltip&#45;&gt;Fonts, Tokens, Base -->
+<g id="edge35" class="edge" data-name="Tooltip-&gt;Fonts, Tokens, Base">
 
-<path fill="none" stroke="black" d="M1568.42,-74.43C1565.8,-73.48 1563.15,-72.65 1560.54,-72 1402.08,-32.51 910.21,-22.29 719.85,-19.77"/>
-<polygon fill="black" stroke="black" points="720.13,-16.28 710.09,-19.65 720.04,-23.28 720.13,-16.28"/>
+<path fill="none" stroke="black" d="M1691.42,-74.41C1688.8,-73.47 1686.15,-72.64 1683.54,-72 1509.73,-29.11 966.54,-20.93 764.9,-19.37"/>
+<polygon fill="black" stroke="black" points="765.08,-15.87 755.06,-19.29 765.03,-22.87 765.08,-15.87"/>
 </g>
+
+
 </g>
 </svg>

--- a/tools/generate-graph.dot
+++ b/tools/generate-graph.dot
@@ -36,6 +36,7 @@ digraph dependencies {
   "Avatar" -> "Fonts, Tokens, Base";
   "Breadcrumbs" -> "Fonts, Tokens, Base";
   "Card" -> "Fonts, Tokens, Base";
+  "Content-Header" -> "Fonts, Tokens, Base";
   "Confirm Dialog" -> "Fonts, Tokens, Base";
   "Divider" -> "Fonts, Tokens, Base";
   "Form" -> "Fonts, Tokens, Base";


### PR DESCRIPTION
## Why?

A page or section content header has shown up as a common pattern desired. This aims to provide that.

This is the first component is almost 2 years with https://github.com/RoleModel/optics/pull/209 being the last one added!

A lot has changed in the implementation of Optics but as usage has increased and more patterns have emerged, new components make sense to add!

## What Changed

- [X] Add Content Header Component
- [X] Add documentation for Content Header
- [X] Add some project specific spelling to workspace

## Sanity Check

- ~~[ ] Have you updated any usage of changed tokens?~~
- [X] Have you updated the docs with any component changes?
- [X] Have you updated the dependency graph with any component changes?
- [X] Have you run linters?
- [X] Have you run prettier?
- [X] Have you tried building the css?
- [X] Have you tried building storybook?
- [X] Do you need to update the package version?

## Screenshots

<img width="306" height="378" alt="Screenshot 2025-07-10 at 8 46 10 PM" src="https://github.com/user-attachments/assets/c87dfd17-b5ca-4e42-af71-32ad73b5643a" />

<img width="1432" height="1002" alt="Screenshot 2025-07-10 at 8 44 45 PM" src="https://github.com/user-attachments/assets/ef698c9b-4431-49ab-9c96-3d970998f131" />
<img width="1415" height="857" alt="Screenshot 2025-07-10 at 8 44 58 PM" src="https://github.com/user-attachments/assets/8503fba4-a149-40b4-89e3-4405d88853dd" />
<img width="1431" height="843" alt="Screenshot 2025-07-10 at 8 45 08 PM" src="https://github.com/user-attachments/assets/777c9241-6d09-496a-9b95-bcd14fec2ad9" />
<img width="1431" height="841" alt="Screenshot 2025-07-10 at 8 45 17 PM" src="https://github.com/user-attachments/assets/2ea08ecb-d184-4742-b5c3-4bd097f50a4f" />
<img width="1428" height="927" alt="Screenshot 2025-07-10 at 8 45 24 PM" src="https://github.com/user-attachments/assets/ff96ab5a-9da6-4f02-850b-e590ca6e0971" />
