### PR TITLE
Add no icons distribution version

### DIFF
--- a/src/optics+no_icons.css
+++ b/src/optics+no_icons.css
@@ -1,0 +1,16 @@
+/* Third party Vendors */
+@import 'modern-css-reset/dist/reset';
+
+/* Fonts */
+@import 'core/fonts/text_fonts.css';
+
+/* Tokens */
+@import 'core/tokens';
+
+/* Base styles and utilities */
+@import 'core/base';
+@import 'core/layout';
+@import 'core/utilities';
+
+/* Components */
+@import 'components';

--- a/src/stories/Components/Icon/Icon.mdx
+++ b/src/stories/Components/Icon/Icon.mdx
@@ -56,7 +56,7 @@ Icon can be used as a standalone component, however, it does have a few dependen
 
 Optics supports a variety of [Additional icon libraries](?path=/docs/overview-addons--docs) that can be imported. Due to the nature of these libraries, not all of the same icon class modifiers may be available.
 
-There are two ways these icon libraries can be used.
+There are three ways these icon libraries can be used.
 
 First is as an addon. This means that the default Material Symbols Outlined icons will still be loaded and both can be used.
 
@@ -69,6 +69,12 @@ Second is to use an alternate Optics import that does not include the default Ma
 
 ```css
 @import '@rolemodel/optics/dist/css/optics+phosphor_icons';
+```
+
+Third is to remove the default Material Symbols Outlined icons and handle icons completely on your own. This will reduce the page load time by not loading any icons.
+
+```css
+@import '@rolemodel/optics/dist/css/optics+no_icons';
 ```
 
 ### Material Symbols Outline Variable Icons

--- a/src/stories/Overview/Introduction.mdx
+++ b/src/stories/Overview/Introduction.mdx
@@ -75,6 +75,8 @@ You can add this import to the top of your root level `css` file.
 /* Or */
 @import '@rolemodel/optics/dist/css/optics'; /* Using a different compiler */
 /* Or */
+@import '@rolemodel/optics/dist/css/optics+no_icons'; /* Don't load the default icons library */
+/* Or */
 @import '@rolemodel/optics/dist/css/optics.min.css'; /* If you want a single file with all the styles in it. */
 /* Or */
 @import '@rolemodel/optics/dist/css/optics+phosphor_icons.css'; /* Using a different icon pack */


### PR DESCRIPTION
## Why?

Add a new distribution version that lets you skip loading icons

## What Changed

- [X] Add new dist version with no icons
- [X] Update docs to reflect

## Quality Assurance

- [X] Have you tagged the PR with the correct labels?
- [X] Have you validated the changes?
  - [X] Have you run linters? (yarn sanity-check)
  - [X] Have you run prettier?
  - [X] Have you tried building the css?
  - [X] Have you tried building storybook?
- ~~[ ] Have you updated any usage of changed tokens?~~
- ~~[ ] Did you add a component?~~
  - ~~[ ] Have you added it to the dependency graph?~~
  - ~~[ ] Have you added it to the docs?~~
- ~~[ ] Did you update a component?~~
  - ~~[ ] Have you updated the dependency graph?~~
  - [X] Have you updated the docs?
- ~~[ ] Do you need to update the package version?~~ Already updated and ready for release
  - ~~[ ] Did you update the example pages in `.storybook/assets`?~~
- [X] Were any changes made to the top level optics.css file?
  - [X] Were those changes reflected in the other top level files?

## Screenshots

<img width="782" height="435" alt="Screenshot 2026-03-05 at 11 13 14 AM" src="https://github.com/user-attachments/assets/3485dfdd-dd11-4c6c-a26a-f5620b4079b9" />
<img width="792" height="185" alt="Screenshot 2026-03-05 at 11 12 49 AM" src="https://github.com/user-attachments/assets/a8943f2b-de94-4d3c-a975-890993489a14" />
