### PR TITLE
Select Only Direct Child Summary When Rotating Accordion Marker

### DIFF
--- a/src/components/accordion.css
+++ b/src/components/accordion.css
@@ -43,7 +43,7 @@
   }
 
   &[open] {
-    summary .accordion__marker {
+    > summary .accordion__marker {
       rotate: 0.25turn;
     }
 


### PR DESCRIPTION
## Why?

The accordion marker was being rotated on every summary within an accordion. If you had a nested accordion, then it would wrongly rotate the marker of the child accordion. 

## What Changed

What changed in this PR?

- [x] Only select direct child summaries when rotating markers

## Quality Assurance

- [x] Have you tagged the PR with the correct labels?
- [x] Have you validated the changes?
  - [x] Have you run linters? (yarn sanity-check)
  - [x] Have you run prettier?
  - [x] Have you tried building the css?
   - [x] Have you tried building storybook?
 ~~- [ ] Have you updated any usage of changed tokens?~~
 ~~-[ ] Did you add a component?~~
   ~~- [ ] Have you added it to the dependency graph?~~
   ~~- [ ] Have you added it to the docs?~~
 ~~-[ ] Did you update a component?~~
 ~~- [ ] Have you updated the dependency graph?~~
   ~~- [ ] Have you updated the docs?~~
 ~~- [ ] Do you need to update the package version?~~
   ~~- [ ] Did you update the example pages in `.storybook/assets`?~~
 ~~- [ ] Were any changes made to the top level optics.css file?~~
   ~~- [ ] Were those changes reflected in the other top level files?~~
